### PR TITLE
Add the ability to specify custom log writers on mockzilla

### DIFF
--- a/lib/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
+++ b/lib/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
@@ -7,9 +7,9 @@ import com.apadmi.mockzilla.lib.internal.stopServer
 import com.apadmi.mockzilla.lib.internal.utils.FileIo
 import com.apadmi.mockzilla.lib.models.MetaData
 import com.apadmi.mockzilla.lib.models.MockzillaConfig
+import com.apadmi.mockzilla.lib.service.toKermitLogWriter
 
 import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Severity
 import co.touchlab.kermit.StaticConfig
 import co.touchlab.kermit.platformLogWriter
 
@@ -23,14 +23,13 @@ fun stopMockzilla() {
 internal fun startMockzilla(
     config: MockzillaConfig,
     metaData: MetaData,
-    fileIo: FileIo,
-    logger: Logger = Logger(
-        StaticConfig(
-            Severity.valueOf(config.logLevel.name),
-            listOf(platformLogWriter())
-        ), "Mockzilla"
-    ),
-) = startMockzilla(config, prepareMockzilla(config, metaData, fileIo, logger))
+    fileIo: FileIo
+) = startMockzilla(config, prepareMockzilla(config, metaData, fileIo, Logger(
+    StaticConfig(
+        config.logLevel.toKermitSeverity(),
+        listOf(platformLogWriter()) + config.additionalLogWriters.map { it.toKermitLogWriter() }
+    ), "Mockzilla"
+)))
 
 internal fun prepareMockzilla(
     config: MockzillaConfig,

--- a/lib/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/service/MockzillaLogWriter.kt
+++ b/lib/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/service/MockzillaLogWriter.kt
@@ -1,0 +1,28 @@
+package com.apadmi.mockzilla.lib.service
+
+import com.apadmi.mockzilla.lib.models.MockzillaConfig
+import com.apadmi.mockzilla.lib.models.MockzillaConfig.LogLevel.Companion.toLogLevel
+
+import co.touchlab.kermit.LogWriter
+import co.touchlab.kermit.Severity
+
+interface MockzillaLogWriter {
+    fun log(
+        logLevel: MockzillaConfig.LogLevel,
+        message: String,
+        tag: String,
+        throwable: Throwable? = null
+    )
+}
+
+@Suppress("EXTENSION_FUNCTION_WITH_CLASS")
+internal fun MockzillaLogWriter.toKermitLogWriter() = object : LogWriter() {
+    override fun log(
+        severity: Severity,
+        message: String,
+        tag: String,
+        throwable: Throwable?
+    ) {
+        this@toKermitLogWriter.log(logLevel = severity.toLogLevel(), message, tag, throwable)
+    }
+}

--- a/lib/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/internal/utils/LogSeverityTests.kt
+++ b/lib/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/internal/utils/LogSeverityTests.kt
@@ -1,0 +1,19 @@
+package com.apadmi.mockzilla.lib.internal.utils
+
+import com.apadmi.mockzilla.lib.models.MockzillaConfig
+import com.apadmi.mockzilla.lib.models.MockzillaConfig.LogLevel.Companion.toLogLevel
+
+import co.touchlab.kermit.Severity
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LogSeverityTests {
+    @Test
+    fun `Kermit severity and mockzilla log level converts correctly`() {
+        assertEquals(MockzillaConfig.LogLevel.values().size, Severity.values().size)
+        MockzillaConfig.LogLevel.values().forEach {
+            assertEquals(it, it.toKermitSeverity().toLogLevel())
+        }
+    }
+}


### PR DESCRIPTION
Can now add log writers to the mockzilla config. These are then called each time Mockzilla performs a log operation as well as writing to standard out.

```
mockzillaConfig.addLogWriter(...)
``