### PR TITLE
fix: exclude all the build folders from Diktat scanning

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -23,7 +23,7 @@ configure<com.diffplug.gradle.spotless.SpotlessExtension> {
 
     kotlin {
         target("**/*.kt")
-        targetExclude("build-logic/build/**", "build/**", "**/mockzilla/build/**", "fastlane/**", "fastlane-build/**")
+        targetExclude("build-logic/build/**", "build/**", "*/build/**", "fastlane/**", "fastlane-build/**")
 
         diktat("1.2.1").configFile("diktat-analysis.yml")
 


### PR DESCRIPTION
It was having a good whinge about the generated Showkase files in the management-ui folder.

Not sure why this wasn't caught in a previous PR?