### PR TITLE
chore: Add mockzilla server to Android management UI

### DIFF
--- a/mockzilla-management-ui/android/build.gradle.kts
+++ b/mockzilla-management-ui/android/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 
 dependencies {
     implementation(project(":mockzilla-management-ui:common"))
+    implementation(project(":mockzilla"))
     implementation(libs.androidx.compose.activity)
 }
 

--- a/mockzilla-management-ui/android/src/main/AndroidManifest.xml
+++ b/mockzilla-management-ui/android/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".mockzilla.RootApplication"
         android:allowBackup="false"

--- a/mockzilla-management-ui/android/src/main/java/com/apadmi/mockzilla/MainActivity.kt
+++ b/mockzilla-management-ui/android/src/main/java/com/apadmi/mockzilla/MainActivity.kt
@@ -5,12 +5,23 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.lifecycleScope
+import com.apadmi.mockzilla.desktop.mock.simulateUseOfDevelopmentServer
+import com.apadmi.mockzilla.desktop.mock.startDevelopmentMockzillaServer
 import com.apadmi.mockzilla.desktop.ui.App
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        val runtimeParams = startDevelopmentMockzillaServer(this)
+
+        lifecycleScope.launch {
+            // Fire off some requests to the dev server to simulate some logs appearing
+            simulateUseOfDevelopmentServer(runtimeParams)
+        }
 
         setContent {
             CompositionLocalProvider {

--- a/mockzilla-management-ui/common/build.gradle.kts
+++ b/mockzilla-management-ui/common/build.gradle.kts
@@ -50,6 +50,12 @@ kotlin {
             implementation(libs.androidx.lifecycleViewModelCompose)
             implementation(libs.koin.android)
             implementation(libs.koin.compose)
+
+            /* Mockzilla */
+            // Android target is only used for development since it's a better dev experience than desktop
+            // So using mockzilla to have a "Mock app" to connect to
+            implementation(project(":mockzilla"))
+            implementation(libs.ktor.client.core)
         }
         val androidUnitTest by getting {
             dependencies {

--- a/mockzilla-management-ui/common/src/androidMain/kotlin/com/apadmi/mockzilla/desktop/mock/DevelopmentMock.kt
+++ b/mockzilla-management-ui/common/src/androidMain/kotlin/com/apadmi/mockzilla/desktop/mock/DevelopmentMock.kt
@@ -1,0 +1,85 @@
+@file:Suppress("MAGIC_NUMBER")
+
+package com.apadmi.mockzilla.desktop.mock
+
+import android.content.Context
+import com.apadmi.mockzilla.lib.models.EndpointConfiguration
+import com.apadmi.mockzilla.lib.models.MockzillaConfig
+import com.apadmi.mockzilla.lib.models.MockzillaHttpResponse
+import com.apadmi.mockzilla.lib.models.MockzillaRuntimeParams
+import com.apadmi.mockzilla.lib.startMockzilla
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.appendPathSegments
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+val endpointWithPresets = EndpointConfiguration.Builder(
+    "endpoint-with-presets"
+)
+    .setDefaultHandler {
+        MockzillaHttpResponse(headers = mapOf("Content-Type" to "application/json"), body = "{}")
+    }
+    .configureDashboardOverrides {
+        addSuccessPreset(MockzillaHttpResponse(HttpStatusCode.Created, headers = emptyMap(), body = ""))
+        addSuccessPreset(MockzillaHttpResponse(body = """{ "hello": "world" }"""))
+
+        addErrorPreset(MockzillaHttpResponse(HttpStatusCode.ServiceUnavailable, body = "Go away"))
+    }
+    .build()
+
+val responseCodesToCycleThrough = listOf(
+    HttpStatusCode.OK,
+    HttpStatusCode.Created,
+    HttpStatusCode.Gone,
+    HttpStatusCode.BadRequest,
+    HttpStatusCode.Unauthorized,
+    HttpStatusCode.Forbidden,
+    HttpStatusCode(418, "I'm a teapot"),
+    HttpStatusCode.TooEarly,
+    HttpStatusCode.BadGateway,
+    HttpStatusCode.InternalServerError,
+)
+val endpointThatCyclesThroughResponseCodes = EndpointConfiguration.Builder(
+    "endpoint-that-cycles-through-response-codes"
+).setDefaultHandler {
+    val code = responseCodesToCycleThrough[currentResponseCode++ % responseCodesToCycleThrough.size]
+    MockzillaHttpResponse(
+        statusCode = code,
+        headers = mapOf("Content-Type" to "application/json"),
+        body = code.description
+    )
+}.build()
+var currentResponseCode = 0
+
+private suspend fun HttpClient.get(
+    runtimeParams: MockzillaRuntimeParams,
+    endpoint: EndpointConfiguration
+) =
+    get(runtimeParams.mockBaseUrl) {
+        url { appendPathSegments(endpoint.key.raw) }
+    }
+
+// This is confusing because it gets a bit meta, but on Android we actually start an instance of the
+// Mockzilla server within the Mockzilla UI so that we don't have to have it running separately for development
+fun startDevelopmentMockzillaServer(context: Context) = startMockzilla(
+    MockzillaConfig.Builder()
+        .setPort(8080)
+        .addEndpoint(endpointWithPresets)
+        .addEndpoint(endpointThatCyclesThroughResponseCodes)
+        .build(),
+    context = context
+)
+
+suspend fun simulateUseOfDevelopmentServer(runtimeParams: MockzillaRuntimeParams) =
+    withContext(Dispatchers.IO) {
+        val client = HttpClient()
+
+        client.get(runtimeParams, endpointWithPresets)
+        repeat(responseCodesToCycleThrough.size * 2) {
+            delay(it * 90L)
+            client.get(runtimeParams, endpointThatCyclesThroughResponseCodes)
+        }
+    }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
@@ -2,6 +2,7 @@ package com.apadmi.mockzilla.desktop.ui.widgets.deviceconnection
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -26,6 +27,9 @@ fun DeviceConnectionWidget() {
 fun DeviceConnectionContent(state: State, onIpAndPortChanged: (String) -> Unit) = Column {
     Text("State: ${state.connectionState}")
     TextField(value = state.ipAndPort, onValueChange = onIpAndPortChanged)
+    Button(onClick = { onIpAndPortChanged("127.0.0.1:8080") }) {
+        Text("Set to localhost:8080")
+    }
 }
 
 @ShowkaseComposable("DeviceConnection-Idle", "DeviceConnection")

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -1,8 +1,6 @@
 package com.apadmi.mockzilla.desktop.ui.widgets.endpoints.endpoints
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState

--- a/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ContextUtils.kt
+++ b/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ContextUtils.kt
@@ -12,7 +12,7 @@ internal val Context.applicationName: String? get() {
     val applicationInfo: ApplicationInfo = applicationInfo
     val stringId = applicationInfo.labelRes
     return if (stringId == 0) {
-        applicationInfo.nonLocalizedLabel.toString()
+        applicationInfo.nonLocalizedLabel?.toString() ?: packageName
     } else {
         getString(
             stringId


### PR DESCRIPTION
This essentially adds a helpful dev mode to deving the UI so that you don't have to manage a separate app to connect to for testing, it just ships with mockzilla itself.



https://github.com/Apadmi-Engineering/Mockzilla/assets/55275568/61411e8a-f7b4-44a3-9bc0-12600a57980c

