### PR TITLE
Feature/adb and emulators

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 
 # Kotlin
+adam = "0.5.7"
 kotlin = "1.9.23" # https://github.com/JetBrains/kotlin
 agp = "8.4.0" # https://developer.android.com/build/releases/gradle-plugin
 ksp = "1.9.23-1.0.20" # https://github.com/google/ksp
@@ -54,6 +55,7 @@ paparazzi = "1.3.1" # https://github.com/cashapp/paparazzi
 [libraries]
 
 # Compose & Material
+adam = { module = "com.malinskiy.adam:adam", version.ref = "adam" }
 androidx-compose-activity = { module = "androidx.activity:activity-compose", version.ref = "compose-activity"  }
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "compose" }
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }

--- a/mockzilla-management-ui/android/build.gradle.kts
+++ b/mockzilla-management-ui/android/build.gradle.kts
@@ -31,4 +31,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    android {
+        packaging {
+            exclude("META-INF/*")
+        }
+    }
 }

--- a/mockzilla-management-ui/common/build.gradle.kts
+++ b/mockzilla-management-ui/common/build.gradle.kts
@@ -33,6 +33,9 @@ kotlin {
 
             /* Mockzilla Management */
             implementation(project(":mockzilla-management"))
+
+            /* ADB */
+            implementation(libs.adam)
         }
         commonTest.dependencies {
             implementation(kotlin("test"))

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/di/UseCaseModule.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/di/UseCaseModule.kt
@@ -1,5 +1,7 @@
 package com.apadmi.mockzilla.desktop.di
 
+import com.apadmi.mockzilla.desktop.engine.adb.AdbConnectorUseCase
+import com.apadmi.mockzilla.desktop.engine.adb.AdbConnectorUseCaseImpl
 import com.apadmi.mockzilla.desktop.engine.device.MetaDataUseCase
 import com.apadmi.mockzilla.desktop.engine.device.MetaDataUseCaseImpl
 import com.apadmi.mockzilla.desktop.engine.device.MonitorLogsUseCase
@@ -10,4 +12,5 @@ import org.koin.dsl.module
 internal fun useCaseModule(): Module = module {
     single<MetaDataUseCase> { MetaDataUseCaseImpl(get()) }
     single<MonitorLogsUseCase> { MonitorLogsUseCaseImpl(get()) }
+    single<AdbConnectorUseCase> { AdbConnectorUseCaseImpl }
 }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/di/ViewModelModule.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/di/ViewModelModule.kt
@@ -11,7 +11,7 @@ import org.koin.core.module.Module
 import org.koin.dsl.module
 
 internal fun viewModelModule(): Module = module {
-    viewModel { DeviceConnectionViewModel(get(), get()) }
+    viewModel { DeviceConnectionViewModel(get(), get(), get()) }
     viewModel { MetaDataWidgetViewModel(get(), get()) }
     viewModel { DeviceTabsViewModel(get(), get()) }
     viewModel { MiddlePaneWrapperViewModel(get()) }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/adb/AdbConnectorUseCase.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/adb/AdbConnectorUseCase.kt
@@ -1,0 +1,140 @@
+package com.apadmi.mockzilla.desktop.engine.adb
+
+import com.malinskiy.adam.AndroidDebugBridgeClient
+import com.malinskiy.adam.AndroidDebugBridgeClientFactory
+import com.malinskiy.adam.interactor.StartAdbInteractor
+import com.malinskiy.adam.request.device.Device
+import com.malinskiy.adam.request.device.DeviceState
+import com.malinskiy.adam.request.device.ListDevicesRequest
+import com.malinskiy.adam.request.forwarding.ListPortForwardsRequest
+import com.malinskiy.adam.request.forwarding.LocalTcpPortSpec
+import com.malinskiy.adam.request.forwarding.PortForwardRequest
+import com.malinskiy.adam.request.forwarding.RemoteTcpPortSpec
+import com.malinskiy.adam.request.prop.GetSinglePropRequest
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
+
+/**
+ * @property name
+ * @property deviceSerial
+ * @property isActive
+ */
+data class AdbConnection(
+    val name: String,
+    val deviceSerial: String,
+    val isActive: Boolean
+)
+
+/**
+ * @property connection
+ * @property localPort
+ */
+data class AdbPortForwardingResult(val connection: AdbConnection, val localPort: Int)
+interface AdbConnectorUseCase {
+    suspend fun listConnectedDevices(): Result<List<AdbConnection>>
+    suspend fun setupPortForwardingIfNeeded(
+        emulator: AdbConnection,
+        localPort: Int,
+        emulatorPort: Int
+    ): Result<AdbPortForwardingResult>
+}
+
+object AdbConnectorUseCaseImpl : AdbConnectorUseCase {
+    private suspend fun prepareAdb(): AndroidDebugBridgeClient {
+        StartAdbInteractor().execute()
+        return AndroidDebugBridgeClientFactory().build()
+    }
+
+    private suspend fun <T> runAdbCommandsSafely(
+        timeout: Duration = 1.seconds,
+        block: suspend (adb: AndroidDebugBridgeClient) -> T
+    ) = withContext(Dispatchers.IO) {
+        withTimeout(timeout) {
+            runCatching {
+                block(prepareAdb())
+            }
+        }
+    }
+
+    override suspend fun listConnectedDevices() = runAdbCommandsSafely { adb ->
+        adb.execute(request = ListDevicesRequest()).map { it.toAdbConnection(adb) }
+    }
+
+    private suspend fun Device.toAdbConnection(
+        adb: AndroidDebugBridgeClient
+    ): AdbConnection {
+        val isActive = state == DeviceState.DEVICE
+        val name = if (isActive) {
+            runCatching { adb.getHumanReadableName(serial) }.getOrNull() ?: serial
+        } else {
+            serial
+        }
+
+        return AdbConnection(name, serial, isActive)
+    }
+
+    override suspend fun setupPortForwardingIfNeeded(
+        emulator: AdbConnection,
+        localPort: Int,
+        emulatorPort: Int
+    ) = runAdbCommandsSafely { adb ->
+        val rules = adb.execute(ListPortForwardsRequest(emulator.deviceSerial))
+        val existingRule = rules.filter {
+            // The `ListPortForwardsRequest` doesn't seem to actually filter by device
+            // serial number so doing that explicitly here
+            it.serial == emulator.deviceSerial
+        }.firstOrNull {
+            (it.remoteSpec as? RemoteTcpPortSpec)?.port == emulatorPort
+        }?.localSpec as? LocalTcpPortSpec
+
+        if (existingRule == null) {
+            adb.addPortForwardingRule(localPort, emulatorPort, emulator)
+        } else {
+            AdbPortForwardingResult(emulator, existingRule.port)
+        }
+    }
+
+    private suspend fun AndroidDebugBridgeClient.addPortForwardingRule(
+        localPort: Int,
+        emulatorPort: Int,
+        emulator: AdbConnection
+    ) = AdbPortForwardingResult(
+        emulator, execute(
+            request = PortForwardRequest(
+                local = LocalTcpPortSpec(localPort),
+                remote = RemoteTcpPortSpec(emulatorPort),
+                serial = emulator.deviceSerial,
+            ),
+        ) ?: throw Exception("Port forwarding failed")
+    )
+
+
+    private suspend fun AndroidDebugBridgeClient.getHumanReadableName(
+        deviceSerial: String
+    ): String = getPropUnlessBlank(
+        deviceSerial = deviceSerial,
+        "ro.boot.qemu.avd_name"
+    ) ?: buildString {
+        getPropUnlessBlank(deviceSerial, "ro.product.name").also {
+            append(it)
+            append(" ")
+        }
+        getPropUnlessBlank(deviceSerial, "ro.product.model").also {
+            append(it)
+            append(" ")
+        }
+        getPropUnlessBlank(deviceSerial, "ro.product.device").also { append(it) }
+    }
+
+    private suspend fun AndroidDebugBridgeClient.getPropUnlessBlank(
+        deviceSerial: String,
+        prop: String
+    ) = execute(
+        request = GetSinglePropRequest(name = prop),
+        serial = deviceSerial
+    ).takeUnless { it.isBlank() }
+}

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionViewModel.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionViewModel.kt
@@ -1,12 +1,13 @@
 package com.apadmi.mockzilla.desktop.ui.widgets.deviceconnection
 
 import androidx.compose.runtime.Immutable
+import com.apadmi.mockzilla.desktop.engine.adb.AdbConnection
+import com.apadmi.mockzilla.desktop.engine.adb.AdbConnectorUseCase
 import com.apadmi.mockzilla.desktop.engine.device.ActiveDeviceSelector
 import com.apadmi.mockzilla.desktop.engine.device.Device
 import com.apadmi.mockzilla.desktop.engine.device.MetaDataUseCase
 import com.apadmi.mockzilla.desktop.viewmodel.ViewModel
 import com.apadmi.mockzilla.lib.models.MetaData
-import com.apadmi.mockzilla.management.MockzillaManagement.*
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,10 +16,20 @@ import kotlinx.coroutines.yield
 
 class DeviceConnectionViewModel(
     private val metaDataUseCase: MetaDataUseCase,
-    private val activeDeviceSelector: ActiveDeviceSelector
+    private val activeDeviceSelector: ActiveDeviceSelector,
+    private val adbConnectorUseCase: AdbConnectorUseCase
 ) : ViewModel() {
     val state = MutableStateFlow(State())
     private var connectionJob: Job? = null
+
+    init {
+        // TODO: This is proof of concept, tidy all this and bullet proof it once Bonjour is brought in
+        viewModelScope.launch {
+            adbConnectorUseCase.listConnectedDevices().onSuccess {
+                state.value = state.value.copy(adbDevices = it)
+            }
+        }
+    }
 
     // TODO: Replace this with better strategies of device connections
     // This is just a rough and ready way to get the UI to be testable
@@ -26,12 +37,28 @@ class DeviceConnectionViewModel(
         connectionJob?.cancel()
         val device = createDeviceOrNull(newValue)
         device ?: run {
-            state.value = State(ipAndPort = newValue, State.ConnectionState.Disconnected)
+            state.value = state.value.copy(
+                ipAndPort = newValue,
+                connectionState = State.ConnectionState.Disconnected
+            )
             return
         }
 
-        state.value = State(ipAndPort = newValue, State.ConnectionState.Connecting)
+        state.value = state.value.copy(
+            ipAndPort = newValue,
+            connectionState = State.ConnectionState.Connecting
+        )
         connectionJob = awaitConnectionAndSetState(device)
+    }
+
+    // TODO: Hardcoding ports now and ignoring real devices just as a proof of concept
+    fun connect8080To0(adbConnection: AdbConnection) = viewModelScope.launch {
+        if (!adbConnection.deviceSerial.startsWith("emulator")) {
+            throw Exception("Non emulators not supported yet")
+        }
+        adbConnectorUseCase.setupPortForwardingIfNeeded(adbConnection, 0, 8080).onSuccess {
+            onIpAndPortChanged("127.0.0.1:${it.localPort}")
+        }.onFailure { throw it }
     }
 
     private fun createDeviceOrNull(ipAndPort: String): Device? {
@@ -59,7 +86,8 @@ class DeviceConnectionViewModel(
     @Immutable
     data class State(
         val ipAndPort: String = "",
-        val connectionState: ConnectionState = ConnectionState.Disconnected
+        val connectionState: ConnectionState = ConnectionState.Disconnected,
+        val adbDevices: List<AdbConnection> = emptyList()
     ) {
         enum class ConnectionState {
             Connected,

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
@@ -2,6 +2,7 @@ package com.apadmi.mockzilla.desktop.ui.widgets.deviceconnection
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -9,6 +10,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 
 import com.apadmi.mockzilla.desktop.di.utils.getViewModel
+import com.apadmi.mockzilla.desktop.engine.adb.AdbConnection
 import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 import com.apadmi.mockzilla.desktop.ui.widgets.deviceconnection.DeviceConnectionViewModel.State
 
@@ -19,18 +21,27 @@ fun DeviceConnectionWidget() {
     val viewModel = getViewModel<DeviceConnectionViewModel>()
     val state by viewModel.state.collectAsState()
 
-    DeviceConnectionContent(state, viewModel::onIpAndPortChanged)
+    DeviceConnectionContent(state, viewModel::onIpAndPortChanged, viewModel::connect8080To0)
 }
 
 @Composable
-fun DeviceConnectionContent(state: State, onIpAndPortChanged: (String) -> Unit) = Column {
+fun DeviceConnectionContent(
+    state: State,
+    onIpAndPortChanged: (String) -> Unit,
+    onTapAdbDevice: (AdbConnection) -> Unit
+) = Column {
     Text("State: ${state.connectionState}")
     TextField(value = state.ipAndPort, onValueChange = onIpAndPortChanged)
+    state.adbDevices.forEach {
+        Button(onClick = { onTapAdbDevice(it) }, enabled = it.isActive) {
+            Text("Connect to ${it.name} (isActive: ${it.isActive})")
+        }
+    }
 }
 
 @ShowkaseComposable("DeviceConnection-Idle", "DeviceConnection")
 @Composable
 @Preview
 fun DeviceConnectionWidgetPreview() = PreviewSurface {
-    DeviceConnectionContent(State()) {}
+    DeviceConnectionContent(State(), {}) {}
 }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -1,8 +1,6 @@
 package com.apadmi.mockzilla.desktop.ui.widgets.endpoints.endpoints
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState


### PR DESCRIPTION
This is just to get the foundations of adb integrations in place to have it in place to work with the bonjour integration that's coming next.

The changes to the DeviceConnectionVM are very much just to make development of the UI easier and as a proof of concept.
