### PR TITLE
feat: Add `setName` method to endpoint builder

### DIFF
--- a/mockzilla-common/src/commonMain/kotlin/com/apadmi/mockzilla/lib/models/EndpointConfiguration.kt
+++ b/mockzilla-common/src/commonMain/kotlin/com/apadmi/mockzilla/lib/models/EndpointConfiguration.kt
@@ -57,6 +57,15 @@ data class EndpointConfiguration(
         )
 
         /**
+         * Sets the human readable name of the endpoint (defaults to the value of the `key`)
+         *
+         * @param name
+         */
+        fun setName(name: String) = apply {
+            config = config.copy(name = name)
+        }
+
+        /**
          * Probability of Mockzilla returning a simulated http error for this endpoint. 100 being a
          * guaranteed error .
          *

--- a/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/integration/ApiIntegrationTests.kt
+++ b/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/integration/ApiIntegrationTests.kt
@@ -33,6 +33,7 @@ class ApiIntegrationTests {
             .setPort(0)  // Port determined at runtime
             .setDelayMillis(100)
             .addEndpoint(EndpointConfiguration.Builder("my-id")
+                .setName("My first endpoint")
                 .setDefaultHandler {
                     MockzillaHttpResponse(
                         HttpStatusCode.Created,
@@ -64,7 +65,7 @@ class ApiIntegrationTests {
                 MockDataResponseDto(
                     listOf(
                         SerializableEndpointConfig.allNulls(
-                            name = "my-id",
+                            name = "My first endpoint",
                             key = "my-id",
                             versionCode = Int.MIN_VALUE
                         )


### PR DESCRIPTION
This should have existed from the beginning, it seems to have been overlooked