### PR TITLE
Feature/zero conf ids

### DIFF
--- a/diktat-analysis.yml
+++ b/diktat-analysis.yml
@@ -37,7 +37,7 @@
 - name: FUNCTION_BOOLEAN_PREFIX
   enabled: true
   configuration:
-    allowedPrefixes: "" # A list of functions that return boolean and are allowed to use. Input is in a form "foo, bar".
+    allowedPrefixes: "getBoolean" # A list of functions that return boolean and are allowed to use. Input is in a form "foo, bar".
 # Checks that function/method name is in lowerCamelCase
 - name: FUNCTION_NAME_INCORRECT_CASE
   enabled: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 # Kotlin
 adam = "0.5.7" # https://github.com/Malinskiy/adam
-jmdns = "3.5.1" # https://github.com/jmdns/jmdns
+jmdns = "3.5.9" # https://github.com/jmdns/jmdns
 kotlin = "1.9.23" # https://github.com/JetBrains/kotlin
 agp = "8.4.0" # https://developer.android.com/build/releases/gradle-plugin
 ksp = "1.9.23-1.0.20" # https://github.com/google/ksp
@@ -41,6 +41,7 @@ material3 = "1.2.1" # https://developer.android.com/jetpack/androidx/releases/co
 compose-activity = "1.9.0" # https://developer.android.com/jetpack/androidx/releases/activity
 
 # Code Formatting
+playServicesAdsIdentifier = "18.1.0"
 semver4j = "3.1.0" # https://github.com/vdurmont/semver4j
 spotless = "6.25.0" # https://github.com/diffplug/spotless
 
@@ -108,6 +109,7 @@ koin-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = 
 # Testing
 mockative = { module = "io.mockative:mockative", version.ref = "mockative" }
 mockative-processor = { module = "io.mockative:mockative-processor", version.ref = "mockative" }
+play-services-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "playServicesAdsIdentifier" }
 semver4j = { module = "com.vdurmont:semver4j", version.ref = "semver4j" }
 showkase = { module = "com.airbnb.android:showkase", version.ref = "showkase" }
 showkase-processor = { module = "com.airbnb.android:showkase-processor", version.ref = "showkase" }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/di/UseCaseModule.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/di/UseCaseModule.kt
@@ -5,6 +5,7 @@ import com.apadmi.mockzilla.desktop.engine.connection.AdbConnectorServiceImpl
 import com.apadmi.mockzilla.desktop.engine.connection.DeviceDetectionUseCase
 import com.apadmi.mockzilla.desktop.engine.connection.DeviceDetectionUseCaseImpl
 import com.apadmi.mockzilla.desktop.engine.connection.ZeroConfSdkWrapper
+import com.apadmi.mockzilla.desktop.engine.connection.isLocalIpAddress
 import com.apadmi.mockzilla.desktop.engine.device.MetaDataUseCase
 import com.apadmi.mockzilla.desktop.engine.device.MetaDataUseCaseImpl
 import com.apadmi.mockzilla.desktop.engine.device.MonitorLogsUseCase
@@ -14,7 +15,7 @@ import com.apadmi.mockzilla.lib.config.ZeroConfConfig
 import org.koin.core.module.Module
 import org.koin.dsl.module
 
-import java.net.InetAddress
+import java.net.NetworkInterface
 
 import kotlinx.coroutines.GlobalScope
 
@@ -24,7 +25,12 @@ internal fun useCaseModule(): Module = module {
     single<AdbConnectorService> { AdbConnectorServiceImpl }
     single { ZeroConfSdkWrapper(ZeroConfConfig.serviceType + ".local.", GlobalScope) }
     single<DeviceDetectionUseCase> {
-        DeviceDetectionUseCaseImpl({ InetAddress.getLocalHost().hostAddress }, get()).also {
+        DeviceDetectionUseCaseImpl(
+            isLocalIpAddress = { address ->
+                NetworkInterface.getNetworkInterfaces().isLocalIpAddress(address)
+            },
+            adbConnectorService = get()
+        ).also {
             get<ZeroConfSdkWrapper>().setListener(it::onChangedServiceEvent)
         }
     }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/AdbConnectorService.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/AdbConnectorService.kt
@@ -56,10 +56,14 @@ object AdbConnectorServiceImpl : AdbConnectorService {
         timeout: Duration = 1.seconds,
         block: suspend (adb: AndroidDebugBridgeClient) -> T
     ) = withContext(Dispatchers.IO) {
-        withTimeout(timeout) {
-            runCatching {
-                block(prepareAdb())
+        try {
+            withTimeout(timeout) {
+                runCatching {
+                    block(prepareAdb())
+                }
             }
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/NetworkingUtils.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/NetworkingUtils.kt
@@ -1,0 +1,36 @@
+// Adapted from: https://github.com/ViToni/JmDNS-examples/blob/master/jmdns-examples/src/main/java/org/kromo/examples/network/NetworkUtils.java
+package com.apadmi.mockzilla.desktop.engine.connection
+
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.util.Enumeration
+
+private const val googleDnsPort = 53
+private val googleDns = InetSocketAddress("8.8.8.8", googleDnsPort)
+
+fun Enumeration<NetworkInterface>.isLocalIpAddress(
+    address: String
+) = toList().any { networkInterface ->
+    networkInterface.inetAddresses.toList().any { it.hostAddress == address }
+}
+
+suspend fun Enumeration<NetworkInterface>.findMdnsAddress(): InetAddress? = toList()
+    .filterNot { networkInterface ->
+        !networkInterface.isUp ||  // a down interface is not useful for us, isn't it
+        !networkInterface.supportsMulticast() ||  // MC is required for mDNS
+        networkInterface.isPointToPoint ||  // we care only about regular interfaces
+        networkInterface.isLoopback  // don't care about loopback addresses
+    }.firstNotNullOfOrNull { networkInterface ->
+        networkInterface.inetAddresses.toList()
+            .filterNot { it.isLinkLocalAddress }
+            .firstOrNull {
+                runCatching {
+                    DatagramSocket(0, it).use { datagramSocket ->
+                        // try to connect to *somewhere*
+                        datagramSocket.connect(googleDns)
+                    }
+                }.getOrNull() != null
+            }
+    }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionViewModel.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionViewModel.kt
@@ -25,8 +25,19 @@ class DeviceConnectionViewModel(
     private var connectionJob: Job? = null
 
     init {
+        val stateOrder = listOf(
+            DetectedDevice.State.ReadyToConnect,
+            DetectedDevice.State.Resolving,
+            DetectedDevice.State.Removed,
+            DetectedDevice.State.NotYourSimulator
+        )
+
         deviceDetectionUseCase.onChangeEvent.onEach {
-            state.value = state.value.copy(devices = deviceDetectionUseCase.devices)
+            state.value = state.value.copy(
+                devices = deviceDetectionUseCase.devices.sortedWith(compareBy {
+                    stateOrder.indexOf(it.state)
+                })
+            )
         }.launchIn(viewModelScope)
     }
 

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
@@ -3,6 +3,7 @@ package com.apadmi.mockzilla.desktop.ui.widgets.deviceconnection
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -120,6 +121,7 @@ fun DeviceConnectionWidgetPreview() = PreviewSurface {
     DeviceConnectionContent(State(), {}, {})
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun DevicesList(
     devices: List<DetectedDevice>,
@@ -142,9 +144,9 @@ private fun DevicesList(
         }
     }
 
-    itemsIndexed(devices) { index, device ->
+    itemsIndexed(devices, key = { _, device -> device.connectionName }) { index, device ->
         Row(
-            modifier = Modifier.alternatingBackground(index).fillMaxWidth()
+            modifier = Modifier.animateItemPlacement().alternatingBackground(index).fillMaxWidth()
                 .padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/mockzilla-management-ui/common/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.kt
+++ b/mockzilla-management-ui/common/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.kt
@@ -1,17 +1,18 @@
 package com.apadmi.mockzilla.desktop.engine.connection
 
-import com.apadmi.mockzilla.desktop.jmds.ServiceTypeAddedListener
 import com.apadmi.mockzilla.desktop.jmds.create
-import com.apadmi.mockzilla.lib.config.ZeroConfConfig
 
 import java.net.InetAddress
+import java.net.NetworkInterface
 import javax.jmdns.JmDNS
 import javax.jmdns.ServiceEvent
 import javax.jmdns.ServiceInfo
 import javax.jmdns.ServiceListener
 
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -19,16 +20,20 @@ actual class ZeroConfSdkWrapper actual constructor(
     private val serviceType: String,
     private val scope: CoroutineScope
 ) : ServiceListener {
-    private val jmdns: JmDNS = JmDNS.create(InetAddress.getLocalHost())
+    private var jmDns: JmDNS? = null
     private lateinit var listener: suspend (ServiceInfoWrapper) -> Unit
-
     actual fun setListener(listener: suspend (ServiceInfoWrapper) -> Unit) {
         this.listener = listener
-        jmdns.addServiceTypeListener(ServiceTypeAddedListener { event ->
-            if (event?.type?.startsWith(ZeroConfConfig.serviceType) == true) {
-                jmdns.addServiceListener(serviceType, this)
+
+        scope.launch {
+            withContext(Dispatchers.IO) {
+                val jmDns = JmDNS.create(awaitLocalIpForMdns()).also {
+                    this@ZeroConfSdkWrapper.jmDns = it
+                }
+                jmDns.registerServiceType(serviceType)
+                jmDns.addServiceListener(serviceType, this@ZeroConfSdkWrapper)
             }
-        })
+        }
     }
 
     override fun serviceAdded(
@@ -38,11 +43,19 @@ actual class ZeroConfSdkWrapper actual constructor(
     private fun serviceChanged(event: ServiceEvent?, state: ServiceInfoWrapper.State) {
         event ?: return
         scope.launch {
-            withContext(Dispatchers.IO) {
-                listener(event.info.parse(state))
+            // If there's no ipv4 addresses there's no way we can connect to it so ignore the Resolved event in this case
+            val shouldCallListener = state == ServiceInfoWrapper.State.Found ||
+                    state == ServiceInfoWrapper.State.Removed ||
+                    state == ServiceInfoWrapper.State.Resolved && event.info.inet4Addresses.isNotEmpty()
+
+            if (shouldCallListener) {
+                listener(
+                    event.info.parse(state)
+                )
             }
         }
     }
+
     override fun serviceRemoved(
         event: ServiceEvent?
     ) = serviceChanged(event, ServiceInfoWrapper.State.Removed)
@@ -50,6 +63,18 @@ actual class ZeroConfSdkWrapper actual constructor(
     override fun serviceResolved(
         event: ServiceEvent?
     ) = serviceChanged(event, ServiceInfoWrapper.State.Resolved)
+
+    private suspend fun awaitLocalIpForMdns(): InetAddress {
+        while (true) {
+            withContext(Dispatchers.IO) {
+                NetworkInterface.getNetworkInterfaces().findMdnsAddress()
+            }?.let {
+                return it
+            }
+
+            delay(1.5.seconds)
+        }
+    }
 
     private fun ServiceInfo.parse(state: ServiceInfoWrapper.State): ServiceInfoWrapper {
         val hostAddresses = (inet6Addresses.toList() + inet4Addresses + inetAddresses).mapNotNull {

--- a/mockzilla-management-ui/common/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/jmds/ServiceInfoWrapper.kt
+++ b/mockzilla-management-ui/common/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/jmds/ServiceInfoWrapper.kt
@@ -9,7 +9,7 @@ internal fun ServiceInfoWrapper.Companion.create(
     state: ServiceInfoWrapper.State
 ) = ServiceInfoWrapper(
     connectionName = info.name,
-    hostAddress = info.hostAddress,
+    hostAddress = info.inet4Addresses.firstOrNull()?.hostAddress ?: info.hostAddress,
     hostAddresses = hostAddresses,
     attributes = info.propertyNames.toList().associateWith { info.getPropertyString(it) },
     port = info.port,

--- a/mockzilla-management-ui/common/src/desktopTest/kotlin/com/apadmi/mockzilla/desktop/engine/connection/DeviceDetectionUseCaseTests.kt
+++ b/mockzilla-management-ui/common/src/desktopTest/kotlin/com/apadmi/mockzilla/desktop/engine/connection/DeviceDetectionUseCaseTests.kt
@@ -89,7 +89,7 @@ class DeviceDetectionUseCaseTests : CoroutineTest() {
                     8_087_854,
                     ServiceInfoWrapper.State.Resolved
                 ),
-                localIpAddress = "my local machine ip address",
+                isLocalIpAddress = true,
                 expectedResult = DetectedDevice(
                     connectionName = "connection name",
                     hostAddress = "host",
@@ -113,7 +113,7 @@ class DeviceDetectionUseCaseTests : CoroutineTest() {
                     1_111_111,
                     ServiceInfoWrapper.State.Resolved
                 ),
-                localIpAddress = "my local machine ip address",
+                isLocalIpAddress = false,
                 expectedResult = DetectedDevice(
                     connectionName = "connection name",
                     hostAddress = "host",
@@ -187,7 +187,7 @@ class DeviceDetectionUseCaseTests : CoroutineTest() {
                 .coroutine { listConnectedDevices() }
                 .thenReturn(Result.success(listOfNotNull(testCase.mockAdbConnection)))
 
-            val sut = DeviceDetectionUseCaseImpl({ testCase.localIpAddress },
+            val sut = DeviceDetectionUseCaseImpl({ testCase.isLocalIpAddress },
                 adbConnectorServiceMock
             )
 
@@ -218,7 +218,7 @@ class DeviceDetectionUseCaseTests : CoroutineTest() {
             13_111_111,
             ServiceInfoWrapper.State.Resolved
         )
-        val sut = DeviceDetectionUseCaseImpl({ "" }, adbConnectorServiceMock)
+        val sut = DeviceDetectionUseCaseImpl({ true }, adbConnectorServiceMock)
 
         /* Run Test */
         sut.onChangedServiceEvent(dummy)
@@ -272,7 +272,7 @@ class DeviceDetectionUseCaseTests : CoroutineTest() {
             13_111_111,
             ServiceInfoWrapper.State.Resolved
         )
-        val sut = DeviceDetectionUseCaseImpl({ "" }, adbConnectorServiceMock)
+        val sut = DeviceDetectionUseCaseImpl({ true }, adbConnectorServiceMock)
 
         /* Run Test */
         sut.onChangedServiceEvent(dummy)
@@ -347,14 +347,14 @@ class DeviceDetectionUseCaseTests : CoroutineTest() {
      * @property caseDescription
      * @property info
      * @property mockAdbConnection
-     * @property localIpAddress
+     * @property isLocalIpAddress
      * @property expectedResult
      */
     data class ChangedServiceEventTestCase(
         val caseDescription: String,
         val info: ServiceInfoWrapper,
         val mockAdbConnection: AdbConnection? = null,
-        val localIpAddress: String = "",
+        val isLocalIpAddress: Boolean = true,
         val expectedResult: DetectedDevice
     )
 }

--- a/mockzilla-management-ui/desktop/build.gradle.kts
+++ b/mockzilla-management-ui/desktop/build.gradle.kts
@@ -28,7 +28,7 @@ compose.desktop {
             packageName = "mockzilla-management-ui"
             packageVersion = rootProject.version.toString().split("-").first()
 
-            jvmArgs("-Dapple.awt.application.appearance=system")
+            jvmArgs("-Dapple.awt.application.appearance=system", "-Djava.net.preferIPv4Stack=true")
         }
     }
 }

--- a/mockzilla/build.gradle.kts
+++ b/mockzilla/build.gradle.kts
@@ -65,6 +65,10 @@ kotlin {
             languageSettings.optIn("kotlinx.coroutines.ExperimentalCoroutinesApi")
         }
 
+        androidMain.dependencies {
+            implementation(libs.play.services.ads.identifier)
+        }
+
         commonMain.dependencies {
             /* Kotlin */
             implementation(libs.kotlinx.coroutines.core)
@@ -113,6 +117,8 @@ android {
 
         consumerProguardFiles("mockzilla-proguard-rules.pro")
     }
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+
 
     compileOptions {
         sourceCompatibility = JavaConfig.version

--- a/mockzilla/src/androidMain/AndroidManifest.xml
+++ b/mockzilla/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>
+</manifest>

--- a/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/AndroidMockzilla.kt
+++ b/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/AndroidMockzilla.kt
@@ -21,5 +21,5 @@ fun startMockzilla(config: MockzillaConfig, context: Context): MockzillaRuntimeP
     fileIo = FileIo(
         context.cacheDir
     ),
-    zeroConfDiscoveryService = ZeroConfDiscoveryServiceImpl(context)
+    zeroConfDiscoveryService = { logger -> ZeroConfDiscoveryServiceImpl(logger, context) }
 )

--- a/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/ZeroConfDiscoveryServiceImpl.kt
+++ b/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/ZeroConfDiscoveryServiceImpl.kt
@@ -3,37 +3,43 @@ package com.apadmi.mockzilla.lib.internal.discovery
 import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
+
+import com.apadmi.mockzilla.lib.config.ZeroConfConfig
 import com.apadmi.mockzilla.lib.models.MetaData
+
+import co.touchlab.kermit.Logger
+import com.google.android.gms.ads.identifier.AdvertisingIdClient
+import com.google.android.gms.common.ConnectionResult
+import com.google.android.gms.common.GoogleApiAvailabilityLight
+
 import java.util.UUID
 
-class ZeroConfDiscoveryServiceImpl(private val context: Context) : ZeroConfDiscoveryService {
+class ZeroConfDiscoveryServiceImpl(
+    private val logger: Logger,
+    private val context: Context
+) : ZeroConfDiscoveryService {
     private val registrationListener = object : NsdManager.RegistrationListener {
         override fun onServiceRegistered(serviceInfo: NsdServiceInfo) {
-            // Save the service name. Android may have changed it in order to
-            // resolve a conflict, so update the name you initially requested
-            // with the name Android actually used.
-            // mServiceName = serviceInfo.serviceName
+            logger.e("ZeroConf Registered: ${serviceInfo.serviceName}")
         }
 
         override fun onRegistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-            // Registration failed! Put debugging code here to determine why.
+            logger.e("ZeroConf Registration failed: $errorCode")
         }
 
         override fun onServiceUnregistered(serviceInfo: NsdServiceInfo) {
-            // Service has been unregistered. This only happens when you call
-            // NsdManager.unregisterService() and pass in this listener.
+            logger.e("ZeroConf Unregistered: ${serviceInfo.serviceType}")
         }
 
         override fun onUnregistrationFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
-            // Unregistration failed. Put debugging code here to determine why.
+            logger.e("ZeroConf Unregistration failed: $errorCode")
         }
     }
 
-    override fun makeDiscoverable(metaData: MetaData, port: Int) {
+    override suspend fun makeDiscoverable(metaData: MetaData, port: Int) {
         val serviceInfo = NsdServiceInfo().apply {
-            // TODO: Persist this to disk so that we're not generating IDs each time
-            serviceName = UUID.randomUUID().toString()
-            serviceType = "_mockzilla._tcp."
+            serviceName = getOrPutDeviceIdentifier()
+            serviceType = ZeroConfConfig.serviceType
             this.port = port
 
             metaData.toMap().forEach {
@@ -46,5 +52,42 @@ class ZeroConfDiscoveryServiceImpl(private val context: Context) : ZeroConfDisco
             NsdManager.PROTOCOL_DNS_SD,
             registrationListener
         )
+    }
+
+    private suspend fun getOrPutDeviceIdentifier(): String {
+        val sharedPrefs = context.getSharedPreferences(sharedPrefsName, Context.MODE_PRIVATE)
+        val identifierOrNull = sharedPrefs.getString(deviceIdentifierKey, null)
+
+        identifierOrNull?.let {
+            return identifierOrNull
+        }
+
+        val newIdentifier = getAdvertiserIdOrNull() ?: UUID.randomUUID().toString()
+        // Save the new identifier in shared preferences even if it's the AdvertisingID.
+        // The AdId could change but we don't really care and pulling the value from shared prefs
+        // should be faster than calling out to Google play.
+        sharedPrefs.edit().putString(deviceIdentifierKey, newIdentifier).apply()
+
+        return newIdentifier
+    }
+
+    private suspend fun getAdvertiserIdOrNull() = if (isGoogleServiceApiAvailable()) {
+        AdvertisingIdClient.getAdvertisingIdInfo(context)
+            .id
+            ?.takeIf { it.isValidAdvertisingId() }
+            .also { logger.d("AdvertiserId found, using it for the ZeroConf service: $it") }
+    } else {
+        null
+    }
+
+    private fun isGoogleServiceApiAvailable() =
+        GoogleApiAvailabilityLight.getInstance()
+            .isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS
+
+    private fun String.isValidAdvertisingId() = isNotBlank() && !(all { it == '-' || it == '0' })
+
+    companion object {
+        private const val deviceIdentifierKey = "device_identifier"
+        private const val sharedPrefsName = "mockzilla_shared_prefs"
     }
 }

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
@@ -31,13 +31,16 @@ internal fun startMockzilla(
     config: MockzillaConfig,
     metaData: MetaData,
     fileIo: FileIo,
-    zeroConfDiscoveryService: ZeroConfDiscoveryService
-) = startMockzilla(config, prepareMockzilla(config, metaData, fileIo, Logger(
-    StaticConfig(
-        config.logLevel.toKermitSeverity(),
-        listOf(platformLogWriter()) + config.additionalLogWriters.map { it.toKermitLogWriter() }
-    ), "Mockzilla"
-), zeroConfDiscoveryService))
+    zeroConfDiscoveryService: (Logger) -> ZeroConfDiscoveryService
+): MockzillaRuntimeParams {
+    val logger = Logger(
+        StaticConfig(
+            config.logLevel.toKermitSeverity(),
+            listOf(platformLogWriter()) + config.additionalLogWriters.map { it.toKermitLogWriter() }
+        ), "Mockzilla"
+    )
+    return startMockzilla(config, prepareMockzilla(config, metaData, fileIo, logger, zeroConfDiscoveryService(logger)))
+}
 
 internal fun prepareMockzilla(
     config: MockzillaConfig,

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.kt
@@ -91,7 +91,7 @@ private fun startNetworkDiscoveryBroadcastIfNeeded(
     job: CompletableJob,
     di: DependencyInjector,
     port: Int
-) = CoroutineScope(job).launch {
+) = CoroutineScope(job).launch(Dispatchers.IO) {
     if (!di.config.isRelease && di.config.isNetworkDiscoveryEnabled) {
         di.logger.i { "Starting network discovery" }
         di.zeroConfDiscoveryService.makeDiscoverable(di.metaData, port)

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/ZeroConfDiscoveryService.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/ZeroConfDiscoveryService.kt
@@ -3,5 +3,5 @@ package com.apadmi.mockzilla.lib.internal.discovery
 import com.apadmi.mockzilla.lib.models.MetaData
 
 interface ZeroConfDiscoveryService {
-    fun makeDiscoverable(metaData: MetaData, port: Int)
+    suspend fun makeDiscoverable(metaData: MetaData, port: Int)
 }

--- a/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/integration/ClearStaleCachesIntegrationTests.kt
+++ b/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/integration/ClearStaleCachesIntegrationTests.kt
@@ -49,7 +49,7 @@ class ClearStaleCachesIntegrationTests {
             mockzillaVersion = ""
         ), fileIo = fileIoForTesting, logger = Logger(StaticConfig()),
         zeroConfDiscoveryService = object : ZeroConfDiscoveryService {
-            override fun makeDiscoverable(metaData: MetaData, port: Int) {
+            override suspend fun makeDiscoverable(metaData: MetaData, port: Int) {
                 /* No-Op */
             }
         }

--- a/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/testutils/IntegrationTestUtils.kt
+++ b/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/testutils/IntegrationTestUtils.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 
 private val zeroConfStub = object : ZeroConfDiscoveryService {
-    override fun makeDiscoverable(metaData: MetaData, port: Int) = Unit
+    override suspend fun makeDiscoverable(metaData: MetaData, port: Int) = Unit
 }
 
 internal typealias SetupBlock = suspend (cacheService: LocalCacheService) -> Unit

--- a/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
+++ b/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
@@ -2,6 +2,7 @@ package com.apadmi.mockzilla.lib
 
 import com.apadmi.mockzilla.lib.internal.discovery.ZeroConfDiscoveryServiceImpl
 import com.apadmi.mockzilla.lib.internal.discovery.validateInfoPlistOrThrow
+import com.apadmi.mockzilla.lib.internal.persistance.KeychainSettings
 import com.apadmi.mockzilla.lib.internal.utils.FileIo
 import com.apadmi.mockzilla.lib.internal.utils.extractMetaData
 import com.apadmi.mockzilla.lib.models.MockzillaConfig
@@ -19,6 +20,10 @@ fun startMockzilla(config: MockzillaConfig): MockzillaRuntimeParams {
         config = config,
         metaData = extractMetaData(),
         fileIo = FileIo(),
-        zeroConfDiscoveryService = ZeroConfDiscoveryServiceImpl()
+        zeroConfDiscoveryService = { _ ->
+            ZeroConfDiscoveryServiceImpl(
+                KeychainSettings("mockzilla_keychain_settings")
+            )
+        }
     )
 }

--- a/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/ZeroConfDiscoveryServiceImpl.kt
+++ b/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/ZeroConfDiscoveryServiceImpl.kt
@@ -3,6 +3,7 @@
 package com.apadmi.mockzilla.lib.internal.discovery
 
 import com.apadmi.mockzilla.lib.config.ZeroConfConfig
+import com.apadmi.mockzilla.lib.internal.persistance.KeychainSettings
 import com.apadmi.mockzilla.lib.models.MetaData
 import com.apadmi.mockzilla.lib.nativedarwin.localdiscovery.BonjourService
 
@@ -11,15 +12,28 @@ import platform.Foundation.NSUUID
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.convert
 
-class ZeroConfDiscoveryServiceImpl : ZeroConfDiscoveryService {
+class ZeroConfDiscoveryServiceImpl(
+    private val keychainSettings: KeychainSettings
+) : ZeroConfDiscoveryService {
     private val bonjour = BonjourService()
 
     @OptIn(ExperimentalForeignApi::class)
-    override fun makeDiscoverable(metaData: MetaData, port: Int) = bonjour.startWithType(
+    override suspend fun makeDiscoverable(metaData: MetaData, port: Int) = bonjour.startWithType(
         ZeroConfConfig.serviceType,
         metaData.toMap().map { it.key to it.value }.toMap(),
         port.convert(),
-        // TODO: Persist this to disk so that we're not generating IDs each time
-        NSUUID.UUID().UUIDString
+        keychainSettings.getDeviceIdentifier()
     )
+
+    private fun KeychainSettings.getDeviceIdentifier() = getStringOrNull(
+        deviceIdentifierKey
+    )?.takeUnless { it.isBlank() } ?: run {
+        val newId = NSUUID().UUIDString
+        putString(deviceIdentifierKey, newId)
+        newId
+    }
+
+    companion object {
+        private const val deviceIdentifierKey = "device_identifier"
+    }
 }

--- a/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/persistance/KeychainSettings.kt
+++ b/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/persistance/KeychainSettings.kt
@@ -1,0 +1,281 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package com.apadmi.mockzilla.lib.internal.persistance
+
+/*
+ * Adapted from: https://github.com/arkivanov/multiplatform-settings/blob/master/multiplatform-settings/src/appleMain/kotlin/com/russhwolf/settings/KeychainSettings.kt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import platform.CoreFoundation.CFArrayGetCount
+import platform.CoreFoundation.CFArrayGetValueAtIndex
+import platform.CoreFoundation.CFArrayRefVar
+import platform.CoreFoundation.CFDictionaryCreate
+import platform.CoreFoundation.CFDictionaryGetValue
+import platform.CoreFoundation.CFDictionaryRef
+import platform.CoreFoundation.CFStringRef
+import platform.CoreFoundation.CFTypeRef
+import platform.CoreFoundation.CFTypeRefVar
+import platform.CoreFoundation.kCFAllocatorDefault
+import platform.CoreFoundation.kCFBooleanFalse
+import platform.CoreFoundation.kCFBooleanTrue
+import platform.Foundation.CFBridgingRelease
+import platform.Foundation.CFBridgingRetain
+import platform.Foundation.NSData
+import platform.Foundation.NSKeyedArchiver
+import platform.Foundation.NSKeyedUnarchiver
+import platform.Foundation.NSNumber
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.create
+import platform.Foundation.dataUsingEncoding
+import platform.Foundation.numberWithBool
+import platform.Foundation.numberWithDouble
+import platform.Foundation.numberWithFloat
+import platform.Foundation.numberWithInt
+import platform.Foundation.numberWithLongLong
+import platform.Security.SecCopyErrorMessageString
+import platform.Security.SecItemAdd
+import platform.Security.SecItemCopyMatching
+import platform.Security.SecItemDelete
+import platform.Security.SecItemUpdate
+import platform.Security.errSecItemNotFound
+import platform.Security.kSecAttrAccount
+import platform.Security.kSecAttrService
+import platform.Security.kSecClass
+import platform.Security.kSecClassGenericPassword
+import platform.Security.kSecMatchLimit
+import platform.Security.kSecMatchLimitAll
+import platform.Security.kSecMatchLimitOne
+import platform.Security.kSecReturnAttributes
+import platform.Security.kSecReturnData
+import platform.Security.kSecValueData
+import platform.darwin.OSStatus
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.MemScope
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArrayOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.value
+
+/**
+ * A collection of storage-backed key-value data
+ *
+ * This class allows storage of values with the [Int], [Long], [String], [Float], [Double], or [Boolean] types, using a
+ * [String] reference as a key. Values will be persisted across app launches.
+ *
+ * The specific persistence mechanism is defined using a platform-specific implementation, so certain behavior may vary
+ * across platforms. In general, updates will be reflected immediately in-memory, but will be persisted to disk
+ * asynchronously.
+ *
+ * Operator extensions are defined in order to simplify usage. In addition, property delegates are provided for cleaner
+ * syntax and better type-safety when interacting with values stored in a `Settings` instance.
+ *
+ * The KeychainSettings implementation saves data to the Apple keychain. Data is saved using the generic password type,
+ * where keys are account names and values are treated as passwords. The value passed to the `String` constructor will
+ * be used as the service name. It's also possible to pass custom key-value pairs as attributes that will be added to
+ * every key, if the default behavior does not fit your needs.
+ */
+class KeychainSettings(vararg defaultProperties: Pair<CFStringRef?, CFTypeRef?>) {
+    @OptIn(ExperimentalForeignApi::class)
+    private val defaultProperties = mapOf(kSecClass to kSecClassGenericPassword) + mapOf(*defaultProperties)
+
+    @Suppress("NULLABLE_PROPERTY_TYPE")
+    val keys: Set<String>
+        get() = memScoped {
+            val attributes = alloc<CFArrayRefVar>()
+            val status = keyChainOperation(
+                kSecMatchLimit to kSecMatchLimitAll,
+                kSecReturnAttributes to kCFBooleanTrue
+            ) { SecItemCopyMatching(it, attributes.ptr.reinterpret()) }
+            status.checkError(errSecItemNotFound)
+            if (status == errSecItemNotFound) {
+                return emptySet()
+            }
+
+            // NB using this instead of List(count) { i -> ... } to avoid platform-dependent Int/Long conversion
+            val count = CFArrayGetCount(attributes.value)
+            val keys = mutableListOf<String>()
+            for (i in 0 until count) {
+                val item: CFDictionaryRef? = CFArrayGetValueAtIndex(attributes.value, i)?.reinterpret()
+                val cfKey: CFStringRef? = CFDictionaryGetValue(item, kSecAttrAccount)?.reinterpret()
+                val nsKey = CFBridgingRelease(cfKey) as NSString
+                keys.add(nsKey.toKstring())
+            }
+
+            return keys.toSet()
+        }
+
+    val size: Int get() = keys.size
+    // NB this calls CFBridgingRetain() without ever calling CFBridgingRelease()
+    constructor(service: String) : this(kSecAttrService to CFBridgingRetain(service))
+
+    fun clear(): Unit = keys.forEach { remove(it) }
+    fun remove(key: String): Unit = removeKeychainItem(key)
+    fun hasKey(key: String): Boolean = hasKeychainItem(key)
+
+    fun putInt(key: String, value: Int): Unit =
+        addOrUpdateKeychainItem(key, archiveNumber(NSNumber.numberWithInt(value)))
+
+    fun getInt(key: String, defaultValue: Int): Int = getIntOrNull(key) ?: defaultValue
+    fun getIntOrNull(key: String): Int? = unarchiveNumber(getKeychainItem(key))?.intValue
+
+    fun putLong(key: String, value: Long): Unit =
+        addOrUpdateKeychainItem(key, archiveNumber(NSNumber.numberWithLongLong(value)))
+
+    fun getLong(key: String, defaultValue: Long): Long = getLongOrNull(key) ?: defaultValue
+    fun getLongOrNull(key: String): Long? = unarchiveNumber(getKeychainItem(key))?.longLongValue
+
+    fun putString(key: String, value: String): Unit =
+        addOrUpdateKeychainItem(key, value.toNsstring().dataUsingEncoding(NSUTF8StringEncoding))
+
+    fun getString(key: String, defaultValue: String): String = getStringOrNull(key) ?: defaultValue
+    @OptIn(BetaInteropApi::class)
+    fun getStringOrNull(key: String): String? =
+        getKeychainItem(key)?.let { NSString.create(it, NSUTF8StringEncoding)?.toKstring() }
+
+    fun putFloat(key: String, value: Float): Unit =
+        addOrUpdateKeychainItem(key, archiveNumber(NSNumber.numberWithFloat(value)))
+
+    fun getFloat(key: String, defaultValue: Float): Float = getFloatOrNull(key) ?: defaultValue
+    fun getFloatOrNull(key: String): Float? = unarchiveNumber(getKeychainItem(key))?.floatValue
+
+    fun putDouble(key: String, value: Double): Unit =
+        addOrUpdateKeychainItem(key, archiveNumber(NSNumber.numberWithDouble(value)))
+
+    fun getDouble(key: String, defaultValue: Double): Double = getDoubleOrNull(key) ?: defaultValue
+    fun getDoubleOrNull(key: String): Double? = unarchiveNumber(getKeychainItem(key))?.doubleValue
+
+    fun putBoolean(key: String, value: Boolean): Unit =
+        addOrUpdateKeychainItem(key, archiveNumber(NSNumber.numberWithBool(value)))
+
+    fun getBoolean(key: String, defaultValue: Boolean): Boolean = getBooleanOrNull(key) ?: defaultValue
+    fun getBooleanOrNull(key: String): Boolean? = unarchiveNumber(getKeychainItem(key))?.boolValue
+
+    private inline fun unarchiveNumber(data: NSData?): NSNumber? =
+        data?.let { NSKeyedUnarchiver.unarchiveObjectWithData(it) } as? NSNumber
+
+    private inline fun archiveNumber(number: NSNumber): NSData? =
+        NSKeyedArchiver.archivedDataWithRootObject(number, true, null)
+
+    private inline fun addOrUpdateKeychainItem(key: String, value: NSData?) {
+        if (hasKeychainItem(key)) {
+            updateKeychainItem(key, value)
+        } else {
+            addKeychainItem(key, value)
+        }
+    }
+
+    private inline fun addKeychainItem(key: String, value: NSData?): Unit = cfRetain(key, value) { (cfKey, cfValue) ->
+        val status = keyChainOperation(
+            kSecAttrAccount to cfKey,
+            kSecValueData to cfValue
+        ) { SecItemAdd(it, null) }
+        status.checkError()
+    }
+
+    private inline fun removeKeychainItem(key: String): Unit = cfRetain(key) { (cfKey) ->
+        val status = keyChainOperation(
+            kSecAttrAccount to cfKey,
+        ) { SecItemDelete(it) }
+        status.checkError(errSecItemNotFound)
+    }
+
+    private inline fun updateKeychainItem(key: String, value: NSData?): Unit =
+        cfRetain(key, value) { (cfKey, cfValue) ->
+            val status = keyChainOperation(
+                kSecAttrAccount to cfKey,
+                kSecReturnData to kCFBooleanFalse
+            ) { SecItemUpdate(it, cfDictionaryOf(kSecValueData to cfValue)) }
+            status.checkError()
+        }
+
+    private inline fun getKeychainItem(key: String): NSData? = cfRetain(key) { (cfKey) ->
+        val cfValue = alloc<CFTypeRefVar>()
+        val status = keyChainOperation(
+            kSecAttrAccount to cfKey,
+            kSecReturnData to kCFBooleanTrue,
+            kSecMatchLimit to kSecMatchLimitOne
+        ) { SecItemCopyMatching(it, cfValue.ptr) }
+        status.checkError(errSecItemNotFound)
+        if (status == errSecItemNotFound) {
+            return@cfRetain null
+        }
+        CFBridgingRelease(cfValue.value) as? NSData
+    }
+
+    private inline fun hasKeychainItem(key: String): Boolean = cfRetain(key) { (cfKey) ->
+        val status = keyChainOperation(
+            kSecAttrAccount to cfKey,
+            kSecMatchLimit to kSecMatchLimitOne
+        ) { SecItemCopyMatching(it, null) }
+
+        status != errSecItemNotFound
+    }
+
+    private inline fun MemScope.keyChainOperation(
+        vararg input: Pair<CFStringRef?, CFTypeRef?>,
+        operation: (query: CFDictionaryRef?) -> OSStatus,
+    ): OSStatus {
+        val query = cfDictionaryOf(defaultProperties + mapOf(*input))
+        return operation(query)
+    }
+
+    private inline fun OSStatus.checkError(vararg expectedErrors: OSStatus) {
+        if (this != 0 && this !in expectedErrors) {
+            val cfMessage = SecCopyErrorMessageString(this, null)
+            val nsMessage = CFBridgingRelease(cfMessage) as? NSString
+            val message = nsMessage?.toKstring() ?: "Unknown error"
+            error("Keychain error $this: $message")
+        }
+    }
+}
+
+internal inline fun MemScope.cfDictionaryOf(vararg items: Pair<CFStringRef?, CFTypeRef?>): CFDictionaryRef? =
+    cfDictionaryOf(mapOf(*items))
+
+internal inline fun MemScope.cfDictionaryOf(map: Map<CFStringRef?, CFTypeRef?>): CFDictionaryRef? {
+    val size = map.size
+    val keys = allocArrayOf(*map.keys.toTypedArray())
+    val values = allocArrayOf(*map.values.toTypedArray())
+    return CFDictionaryCreate(
+        kCFAllocatorDefault,
+        keys.reinterpret(),
+        values.reinterpret(),
+        size.convert(),
+        null,
+        null
+    )
+}
+
+// Turn casts into dot calls for better readability
+@Suppress("CAST_NEVER_SUCCEEDS")
+internal inline fun String.toNsstring() = this as NSString
+
+@Suppress("CAST_NEVER_SUCCEEDS")
+internal inline fun NSString.toKstring() = this as String
+
+internal inline fun <T> cfRetain(vararg values: Any?, block: MemScope.(Array<CFTypeRef?>) -> T): T = memScoped {
+    val cfValues = Array(values.size) { i -> CFBridgingRetain(values[i]) }
+    return try {
+        block(cfValues)
+    } finally {
+        cfValues.forEach { CFBridgingRelease(it) }
+    }
+}

--- a/mockzilla/src/jvmMain/kotlin/com/apadmi/mockzilla/lib/JvmMockzilla.kt
+++ b/mockzilla/src/jvmMain/kotlin/com/apadmi/mockzilla/lib/JvmMockzilla.kt
@@ -35,10 +35,11 @@ fun startMockzilla(
         runTarget = RunTarget.Jvm,
         mockzillaVersion = BuildKonfig.VERSION_NAME
     ),
-    FileIo(Files.createTempDirectory("").toFile()),
+    FileIo(Files.createTempDirectory("").toFile())
+) {
     object : ZeroConfDiscoveryService {
-        override fun makeDiscoverable(metaData: MetaData, port: Int) {
+        override suspend fun makeDiscoverable(metaData: MetaData, port: Int) {
             Logger.i(tag = "Mockzilla") { "ZeroConf not supported for JVM Mockzilla" }
         }
     }
-)
+}


### PR DESCRIPTION
This PR does a few key things:
1. Fixes a multitude of issues with the desktop implementation of the ZeroConf discovery
2. Uses persisted IDs for the device ids used by Bonjour (keychain used on iOS and AdvertisingId on Android)
3. Uses a JVM arg to prefer IPV4 stack since without this it doesn't work at all on Windows.

Windows and OSX device detection now seems pretty stable. Linux is still entirely untested.