### PR TITLE
Feature/fix releases

### DIFF
--- a/.github/workflows/action_deploy_binaries.yml
+++ b/.github/workflows/action_deploy_binaries.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - release-please--branches--develop--components--release-please-action
     tags:
-      - v**
+      - mockzilla-v**
 env:
   is_snapshot: ${{ github.ref_type == 'branch' }}
 

--- a/.github/workflows/action_deploy_desktop_app.yml
+++ b/.github/workflows/action_deploy_desktop_app.yml
@@ -2,10 +2,9 @@ name: Deploy Desktop app
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: [ Deploy Binaries ]
-    types:
-      - completed
+  push:
+    tags:
+      - mockzilla-management-ui-v**
 
 env:
   MAC_CERTIFICATE_PATH: "./osx_build_certificate.p12"

--- a/build-logic/src/main/kotlin/publication-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/publication-convention.gradle.kts
@@ -6,6 +6,13 @@ plugins {
 
 publishing {
     afterEvaluate {
+        if (isSnapshot()) {
+            version = "$version-SNAPSHOT"
+            logger.warn("Publishing to snapshot repository ($version)")
+        } else {
+            logger.warn("Publishing to live repository ($version)")
+        }
+
         repositories.maven(mavenUrl()) {
             name = "OSSRH"
 
@@ -66,8 +73,10 @@ if (hasKey) {
     }
 }
 
-fun mavenUrl() = if (version.toString().endsWith("-SNAPSHOT")) {
+fun mavenUrl() = if (isSnapshot()) {
     "https://s01.oss.sonatype.org/content/repositories/snapshots/"
 } else {
     "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
 }
+
+private fun isSnapshot() = project.properties["is_snapshot"].toString().toBoolean()

--- a/docs/docs/desktop/overview.md
+++ b/docs/docs/desktop/overview.md
@@ -16,7 +16,7 @@ Your device should be automatically discovered by Mockzilla (you may need to res
 ![alt text](img/device_connection.png "Device connection")
 
 !!! note
-    If network discovery does find your device you can manually type in the IP address of your device. (Don't forget the port!)
+    If network discovery does not find your device you can manually type in the IP address of your device. (Don't forget the port!)
 
 ### (2): Edit the mock data
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -71,14 +71,6 @@ Publish to maven local
 
 Publish to maven remote
 
-### get_version_name
-
-```sh
-[bundle exec] fastlane get_version_name
-```
-
-
-
 ### flutter_lib_pull_request
 
 ```sh

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,23 +1,20 @@
 {
+  "release-type": "simple",
   "packages": {
     "mockzilla": {
-      "release-type": "java",
       "release-as": "2.0.0",
       "component": "mockzilla",
       "extra-files": ["build.gradle.kts"]
     },
     "mockzilla-common": {
-      "release-type": "java",
       "component": "mockzilla-common",
       "extra-files": ["build.gradle.kts"]
     },
     "mockzilla-management": {
-      "release-type": "java",
       "component": "mockzilla-management",
       "extra-files": ["build.gradle.kts"]
     },
     "FlutterMockzilla": {
-      "release-type": "simple",
       "release-as": "1.0.0",
       "component": "flutter-mockzilla",
       "extra-files": [
@@ -40,7 +37,6 @@
       ]
     },
     "mockzilla-management-ui": {
-      "release-type": "simple",
       "release-as": "1.0.0",
       "component": "mockzilla-management-ui",
       "extra-files": ["desktop/build.gradle.kts"]


### PR DESCRIPTION
This PR should fix all our problems with releases. Snapshot builds will fire on each merge to development (if there's something releasable).

The manifest config for release-please is now configured such that we can have different versioning based on package, i.e we can release an increment of the desktop app without releasing all the binaries.
