### PR TITLE
Feature/issue 93 desktop wifi changes

### DIFF
--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/NetworkingUtils.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/NetworkingUtils.kt
@@ -2,7 +2,6 @@
 package com.apadmi.mockzilla.desktop.engine.connection
 
 import java.net.DatagramSocket
-import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.NetworkInterface
 import java.util.Enumeration
@@ -16,7 +15,7 @@ fun Enumeration<NetworkInterface>.isLocalIpAddress(
     networkInterface.inetAddresses.toList().any { it.hostAddress == address }
 }
 
-suspend fun Enumeration<NetworkInterface>.findMdnsAddress(): InetAddress? = toList()
+suspend fun Enumeration<NetworkInterface>.findMdnsAddresses() = toList()
     .filterNot { networkInterface ->
         !networkInterface.isUp ||  // a down interface is not useful for us, isn't it
         !networkInterface.supportsMulticast() ||  // MC is required for mDNS
@@ -25,7 +24,7 @@ suspend fun Enumeration<NetworkInterface>.findMdnsAddress(): InetAddress? = toLi
     }.firstNotNullOfOrNull { networkInterface ->
         networkInterface.inetAddresses.toList()
             .filterNot { it.isLinkLocalAddress }
-            .firstOrNull {
+            .filter {
                 runCatching {
                     DatagramSocket(0, it).use { datagramSocket ->
                         // try to connect to *somewhere*
@@ -33,4 +32,4 @@ suspend fun Enumeration<NetworkInterface>.findMdnsAddress(): InetAddress? = toLi
                     }
                 }.getOrNull() != null
             }
-    }
+    } ?: emptyList()

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/NetworkingUtils.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/NetworkingUtils.kt
@@ -2,6 +2,7 @@
 package com.apadmi.mockzilla.desktop.engine.connection
 
 import java.net.DatagramSocket
+import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.NetworkInterface
 import java.util.Enumeration
@@ -15,7 +16,7 @@ fun Enumeration<NetworkInterface>.isLocalIpAddress(
     networkInterface.inetAddresses.toList().any { it.hostAddress == address }
 }
 
-suspend fun Enumeration<NetworkInterface>.findMdnsAddresses() = toList()
+suspend fun Enumeration<NetworkInterface>.findMdnsAddresses(): List<InetAddress> = toList()
     .filterNot { networkInterface ->
         !networkInterface.isUp ||  // a down interface is not useful for us, isn't it
         !networkInterface.supportsMulticast() ||  // MC is required for mDNS

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,7 +37,6 @@
       ]
     },
     "mockzilla-management-ui": {
-      "release-as": "1.0.0",
       "component": "mockzilla-management-ui",
       "extra-files": ["desktop/build.gradle.kts"]
     }


### PR DESCRIPTION
fix: Issue(93) This now periodically refreshes the jmdns instances as the wifi changes

This ensures that switching between wifi networks keeps the list of devices correct. Hopefully it should also solve any wierdness caused by multiple active network adapters too.
