### PR TITLE
Feature/presets visibility

### DIFF
--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
@@ -494,10 +494,15 @@ private fun PresetsSelector(
                     Text("Apply Preset")
                 }
             }
+            val maxLines = if (index == 0) {
+                20
+            } else {
+                3
+            }
             Text(
                 modifier = Modifier.alpha(0.5f),
                 text = preset.response.body,
-                maxLines = 15,
+                maxLines = maxLines,
                 overflow = TextOverflow.Ellipsis,
             )
         }

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
@@ -348,26 +348,6 @@ private fun EndpointDetailsResponseBody(
 ) = Column(modifier = modifier) {
     Spacer(Modifier.height(4.dp))
     var pickingStatusCode by remember { mutableStateOf(false) }
-    var pickingPresets by remember { mutableStateOf(false) }
-
-    if (presets.isNotEmpty()) {
-        Button(
-            modifier = Modifier.align(Alignment.End).padding(horizontal = 8.dp),
-            onClick = { pickingPresets = !pickingPresets }) {
-            Text(if (pickingPresets) "Hide Presets" else "Show Presets")
-        }
-    }
-
-    if (pickingPresets) {
-        HorizontalDivider(Modifier.fillMaxWidth())
-        PresetsSelector(
-            presets = presets,
-            onPresetSelected = {
-                pickingPresets = false
-                onPresetSelected(it)
-            }
-        )
-    }
 
     ExposedDropdownMenuBox(
         expanded = pickingStatusCode,
@@ -480,29 +460,46 @@ private fun EndpointDetailsResponseBody(
     }
     Spacer(modifier = Modifier.heightIn(8.dp))
     HeadersEditor(headers, onHeadersChange)
+    Spacer(modifier = Modifier.heightIn(8.dp))
+    PresetsSelector(
+        presets = presets,
+        onPresetSelected = onPresetSelected,
+    )
 }
 
 @Composable
 private fun PresetsSelector(
     presets: List<DashboardOverridePreset>,
     onPresetSelected: (DashboardOverridePreset) -> Unit
-) = LazyColumn(Modifier.heightIn(max = 200.dp)) {
-    itemsIndexed(presets) { index, preset ->
-        Row(Modifier.fillMaxWidth().alternatingBackground(index).padding(8.dp)) {
-            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                Text(preset.name)
-                Text(
-                    modifier = Modifier.alpha(0.5f),
-                    text = preset.description ?: "",
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
+) = Column {
+    presets.forEachIndexed { index, preset ->
+        Column(
+            modifier = Modifier.fillMaxWidth().alternatingBackground(index).padding(8.dp),
+        ) {
+            Row {
+                Column(
+                    modifier = Modifier.weight(1F),
+                    verticalArrangement = Arrangement.spacedBy(2.dp)
+                ) {
+                    Text(preset.name)
+                    Text(
+                        modifier = Modifier.alpha(0.75f),
+                        text = preset.description ?: "",
+                        style = MaterialTheme.typography.bodySmall,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Button(onClick = { onPresetSelected(preset) }) {
+                    Text("Apply Preset")
+                }
             }
-            Spacer(Modifier.weight(1f))
-            Button(onClick = { onPresetSelected(preset) }) {
-                Text("Apply Preset")
-            }
+            Text(
+                modifier = Modifier.alpha(0.5f),
+                text = preset.response.body,
+                maxLines = 15,
+                overflow = TextOverflow.Ellipsis,
+            )
         }
     }
 }


### PR DESCRIPTION
One of the main benefits of the old web portal UI is that it showed the 'default' response for each endpoint without needing any additional clicks. Since Mockzilla can now have dynamic responses defined in code that UI isn't appropriate for Mockzilla 2's endpoint editor UI. However, by adding the body of each preset to the endpoint editor and removing any clicks to view them we can still provide a useful reference of the 'default' response (and others). Since there could be a lot of presets and the response bodies could be very long this PR limits the first to 20 lines and the rest to 3, these heuristics could be easily tweaked later or made user configurable if needed.

<img width="1243" alt="Screenshot 2024-06-21 at 15 16 23" src="https://github.com/Apadmi-Engineering/Mockzilla/assets/13869843/297009f0-bda3-4de1-97eb-db5e3d2545f1">
