### PR TITLE
Migrate to hosted dependencies

### DIFF
--- a/FlutterMockzilla/mockzilla/README.md
+++ b/FlutterMockzilla/mockzilla/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-    <img src="../../icon.svg" height=200>
+    <img src="https://raw.githubusercontent.com/Apadmi-Engineering/Mockzilla/develop/icon.svg" height=200>
 </p>
 
 A Flutter plugin for running and configuring a local, mock HTTP server that allows your mobile app to simulate calls to a REST API.
 
-**Full documentation available at [here!](https://apadmi-engineering.github.io/Mockzilla/)**
+**Full documentation available [here!](https://apadmi-engineering.github.io/Mockzilla/)**
 
 ## Why use Mockzilla?
 

--- a/FlutterMockzilla/mockzilla/example/pubspec.lock
+++ b/FlutterMockzilla/mockzilla/example/pubspec.lock
@@ -397,23 +397,26 @@ packages:
   mockzilla_android:
     dependency: transitive
     description:
-      path: "../../mockzilla_android"
-      relative: true
-    source: path
+      name: mockzilla_android
+      sha256: "797b4382629c5ea4542f8ed5ce62355d95aa6f0cc23772f8e1fd322bb3ef221a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   mockzilla_ios:
     dependency: transitive
     description:
-      path: "../../mockzilla_ios"
-      relative: true
-    source: path
+      name: mockzilla_ios
+      sha256: ff85ff677977d88acd7011475489b106413d209f7a83938e23d911d53d96f7a0
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   mockzilla_platform_interface:
     dependency: transitive
     description:
-      path: "../../mockzilla_platform_interface"
-      relative: true
-    source: path
+      name: mockzilla_platform_interface
+      sha256: cd78c78137af887f019ec6b223fa565306df7c27278fff2a47d39efea884f5fc
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   package_config:
     dependency: transitive

--- a/FlutterMockzilla/mockzilla/lib/src/mockzilla.dart
+++ b/FlutterMockzilla/mockzilla/lib/src/mockzilla.dart
@@ -4,5 +4,6 @@ abstract class Mockzilla {
   static Future<void> startMockzilla(MockzillaConfig config) =>
       MockzillaPlatform.instance.startMockzilla(config);
 
-  static Future<void> stopMockzilla() => MockzillaPlatform.instance.stopMockzilla();
+  static Future<void> stopMockzilla() =>
+      MockzillaPlatform.instance.stopMockzilla();
 }

--- a/FlutterMockzilla/mockzilla/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
 
 environment:
   sdk: '>=3.1.0 <4.0.0'
-  flutter: ">=1.17.0"
+  flutter: '>=3.3.0'
 
 dependencies:
   flutter:

--- a/FlutterMockzilla/mockzilla/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla/pubspec.yaml
@@ -18,14 +18,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # TODO: Local dependencies used for ease of development, these should be regular dependencies
-  # once this plugin is hosted.
-  mockzilla_platform_interface:
-    path: ../mockzilla_platform_interface
-  mockzilla_android:
-    path: ../mockzilla_android
-  mockzilla_ios:
-    path: ../mockzilla_ios
+  mockzilla_platform_interface: ^0.1.0
+  mockzilla_android: ^0.1.0
+  mockzilla_ios: ^0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla_android/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_android/pubspec.yaml
@@ -27,10 +27,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  # TODO: Local dependencies used for ease of development, these should be regular dependencies
-  # once this plugin is hosted.
-  mockzilla_platform_interface:
-    path: ../mockzilla_platform_interface
+  mockzilla_platform_interface: ^0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla_ios/example/lib/main.dart
+++ b/FlutterMockzilla/mockzilla_ios/example/lib/main.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
-import 'dart:async';
 
-import 'package:flutter/services.dart';
 import 'package:mockzilla_ios/mockzilla_ios.dart';
-import 'package:mockzilla_platform_interface/mockzilla_platform_interface.dart';
 
 void main() {
   runApp(const MyApp());
@@ -17,8 +14,6 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  final _mockzillaIosPlugin = MockzillaIos();
-
   @override
   void initState() {
     super.initState();

--- a/FlutterMockzilla/mockzilla_ios/example/pubspec.lock
+++ b/FlutterMockzilla/mockzilla_ios/example/pubspec.lock
@@ -176,14 +176,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.1.0"
   mockzilla_platform_interface:
     dependency: transitive
     description:
-      path: "../../mockzilla_platform_interface"
-      relative: true
-    source: path
-    version: "0.0.1"
+      name: mockzilla_platform_interface
+      sha256: cd78c78137af887f019ec6b223fa565306df7c27278fff2a47d39efea884f5fc
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   path:
     dependency: transitive
     description:

--- a/FlutterMockzilla/mockzilla_ios/ios/Classes/MockzillaIos.swift
+++ b/FlutterMockzilla/mockzilla_ios/ios/Classes/MockzillaIos.swift
@@ -36,14 +36,16 @@ class MockzillaIos: Thread, MockzillaHostApi {
                 do {
                     var result: Result<Bool, FlutterError> = Result.failure(FlutterError())
                     let nativeRequest = try BridgeMockzillaHttpRequest.fromNative(request)
-                    self.handler.endpointMatcher(
-                        request: nativeRequest,
-                        key: key,
-                        completion: { localResult in
-                            result = localResult
-                            self.matcherSemaphore.signal()
-                        }
-                    )
+                    DispatchQueue.main.async {
+                        self.handler.endpointMatcher(
+                            request: nativeRequest,
+                            key: key,
+                            completion: { localResult in
+                                result = localResult
+                                self.matcherSemaphore.signal()
+                            }
+                        )
+                    }
                     self.matcherSemaphore.wait()
                     return try result.get()
                 } catch {
@@ -54,14 +56,16 @@ class MockzillaIos: Thread, MockzillaHostApi {
                 do {
                     var result: Result<BridgeMockzillaHttpResponse, FlutterError> = Result.failure(FlutterError())
                     let nativeRequest = try BridgeMockzillaHttpRequest.fromNative(request)
-                    self.handler.defaultHandler(
-                        request: nativeRequest,
-                        key: key,
-                        completion: { localResult in
-                            result = localResult
-                            self.handlerSemaphore.signal()
-                        }
-                    )
+                    DispatchQueue.main.async {
+                        self.handler.defaultHandler(
+                            request: nativeRequest,
+                            key: key,
+                            completion: { localResult in
+                                result = localResult
+                                self.handlerSemaphore.signal()
+                            }
+                        )
+                    }
                     self.handlerSemaphore.wait()
                     return try result.map { response in response.toNative() }.get()
                 } catch {
@@ -72,14 +76,16 @@ class MockzillaIos: Thread, MockzillaHostApi {
                 do {
                     var result: Result<BridgeMockzillaHttpResponse, FlutterError> = Result.failure(FlutterError())
                     let nativeRequest = try BridgeMockzillaHttpRequest.fromNative(request)
-                    self.handler.errorHandler(
-                        request: nativeRequest,
-                        key: key,
-                        completion: { localResult in
-                            result = localResult
-                            self.errorHandlerSemaphore.signal()
-                        }
-                    )
+                    DispatchQueue.main.async {
+                        self.handler.errorHandler(
+                            request: nativeRequest,
+                            key: key,
+                            completion: { localResult in
+                                result = localResult
+                                self.errorHandlerSemaphore.signal()
+                            }
+                        )
+                    }
                     self.errorHandlerSemaphore.wait()
                     return try result.map { response in response.toNative() }.get()
                 } catch {

--- a/FlutterMockzilla/mockzilla_ios/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ios/pubspec.yaml
@@ -18,10 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  # TODO: Local dependencies used for ease of development, these should be regular dependencies
-  # once this plugin is hosted.
-  mockzilla_platform_interface:
-    path: ../mockzilla_platform_interface
+  mockzilla_platform_interface: ^0.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Change local dependencies to pub.dev dependencies in preparation for publishing.
- Resolves warning about calling Flutter API methods from platform thread in `mockzilla_ios`