### PR TITLE
fix: Fix android crash in release mode with minify enabled = true

### DIFF
--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
@@ -27,7 +25,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.kt
@@ -9,21 +9,24 @@ import com.apadmi.mockzilla.lib.internal.utils.JsonProvider
 import com.apadmi.mockzilla.lib.internal.utils.environment
 import com.apadmi.mockzilla.lib.models.MockzillaConfig
 import com.apadmi.mockzilla.lib.models.MockzillaRuntimeParams
+import io.ktor.serialization.kotlinx.json.json
 
-import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.cio.*
 import io.ktor.server.engine.*
-import io.ktor.server.plugins.contentnegotiation.*
-import io.ktor.server.plugins.ratelimit.*
-import io.ktor.server.routing.*
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.routing.IgnoreTrailingSlash
 
 import kotlinx.coroutines.*
 
 private var server: ApplicationEngine? = null
 private var job: Job? = null
 
-private fun Application.setupReleaseMode(config: MockzillaConfig, tokensService: TokensService) {
+private inline fun Application.setupReleaseMode(
+    config: MockzillaConfig,
+    tokensService: TokensService
+) {
     install(SimpleAuthPlugin) {
         headerKey = AuthenticationConstants.headerKey
         headerValueIsValid = tokensService::isTokenValid
@@ -39,6 +42,17 @@ private fun Application.setupReleaseMode(config: MockzillaConfig, tokensService:
     }
 }
 
+private fun Application.setupServerEnvironment(job: CompletableJob, di: DependencyInjector) {
+    install(IgnoreTrailingSlash)
+    install(ContentNegotiation) {
+        json(JsonProvider.json)
+    }
+    if (di.config.isRelease) {
+        setupReleaseMode(di.config, di.tokensService)
+    }
+    configureEndpoints(job, di)
+}
+
 internal fun startServer(port: Int, di: DependencyInjector) = runBlocking {
     stopServer()
 
@@ -50,18 +64,9 @@ internal fun startServer(port: Int, di: DependencyInjector) = runBlocking {
         port,
         // Only allow localhost connections in release mode. This stops anyone on the network from
         // being able to hit the server.
-        host = if (di.config.isRelease || di.config.localhostOnly) "127.0.0.1" else "0.0.0.0"
+        host = if (di.config.isRelease || di.config.localhostOnly) "127.0.0.1" else "0.0.0.0",
     ) {
-        install(IgnoreTrailingSlash)
-        install(ContentNegotiation) {
-            json(JsonProvider.json)
-        }
-
-        if (di.config.isRelease) {
-            setupReleaseMode(di.config, di.tokensService)
-        }
-
-        configureEndpoints(job, di)
+        setupServerEnvironment(job, di)
     }).apply {
         server = this
         start(wait = false)


### PR DESCRIPTION
I think this might actually be a ktor/kotlin bug. The crash is on this line in Ktor https://github.com/ktorio/ktor/blob/2.3.12/ktor-server/ktor-server-host-common/jvm/src/io/ktor/server/engine/internal/CallableUtils.kt#L43.

But why this class (which is just an anonymous function) has multiple constructors I have no idea. The release mode if statement is what for some reason causes a second constructor to be generated, which I can't see any reason for. The fix here is putting one function call in the server environment setup callback without any conditional branches.