### PR TITLE
Fix Cocoapods releases

### DIFF
--- a/.github/workflows/action_deploy_binaries.yml
+++ b/.github/workflows/action_deploy_binaries.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Deploy package to Github for SPM & Cocoapods
         run: bundle exec fastlane ios publish_swift_package is_snapshot:$is_snapshot
         env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           IOS_DEPLOY_URL: ${{ secrets.IOS_DEPLOY_URL }}
       - uses: googleapis/release-please-action@v4
         with:

--- a/fastlane/fastfiles/lib.rb
+++ b/fastlane/fastfiles/lib.rb
@@ -59,7 +59,10 @@ platform :ios do
             })
 
             # Push podspec to trunk
-            sh("pod trunk push")
+            sh(%{
+                cd apadmi-mockzilla-ios
+                pod trunk push
+            })
         end
     end
 end


### PR DESCRIPTION
- Adds `cd` command prior to `pod trunk push` to ensure the latter is run from the correct directory.
- Makes `COCOAPODS_TRUNK_TOKEN` available in `publish_swift_package` Fastlane script