### PR TITLE
Fix Cocoapods version

### DIFF
--- a/mockzilla/build.gradle.kts
+++ b/mockzilla/build.gradle.kts
@@ -45,7 +45,7 @@ kotlin {
             baseName = "mockzilla"
         }
         license = "{:type => 'MIT', :file => 'LICENSE'}"
-        source = "{ :git => 'https://github.com/Apadmi-Engineering/SwiftMockzilla.git', :tag => 'v$version' }"
+        source = "{ :git => 'https://github.com/Apadmi-Engineering/SwiftMockzilla.git', :tag => 'v${getVersion()}' }"
         extraSpecAttributes["vendored_frameworks"] = "'Mockzilla.xcframework'"
         extraSpecAttributes["source_files"] = "'Sources/SwiftMockzilla/SwiftMockzilla.swift'"
         extraSpecAttributes["swift_version"] = "'5.9.2'"


### PR DESCRIPTION
- Updates Cocoapods plugin config in `build.gradle.kts` to obtain version from Gradle project instead of using the not yet set Cocoapods version