### PR TITLE
Fix AGP 8 incompatibility

### DIFF
--- a/FlutterMockzilla/mockzilla_android/android/src/main/AndroidManifest.xml
+++ b/FlutterMockzilla/mockzilla_android/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.apadmi.mockzilla">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/FlutterMockzilla/mockzilla_android/lib/src/api_utils.dart
+++ b/FlutterMockzilla/mockzilla_android/lib/src/api_utils.dart
@@ -135,6 +135,7 @@ extension MockzillaConfigBridge on MockzillaConfig {
         isRelease: isRelease,
         localHostOnly: localHostOnly,
         logLevel: logLevel.toBridge(),
+        releaseModeConfig: releaseModeConfig.toBridge(),
       );
 }
 

--- a/FlutterMockzilla/mockzilla_android/lib/src/messages.g.dart
+++ b/FlutterMockzilla/mockzilla_android/lib/src/messages.g.dart
@@ -7,9 +7,7 @@ import 'dart:typed_data' show Float64List, Int32List, Int64List, Uint8List;
 
 import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer;
 import 'package:flutter/services.dart';
-
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -198,6 +196,7 @@ class BridgeMockzillaConfig {
     required this.isRelease,
     required this.localHostOnly,
     required this.logLevel,
+    required this.releaseModeConfig,
   });
 
   int port;
@@ -210,6 +209,8 @@ class BridgeMockzillaConfig {
 
   BridgeLogLevel logLevel;
 
+  BridgeReleaseModeConfig releaseModeConfig;
+
   Object encode() {
     return <Object?>[
       port,
@@ -217,6 +218,7 @@ class BridgeMockzillaConfig {
       isRelease,
       localHostOnly,
       logLevel.index,
+      releaseModeConfig.encode(),
     ];
   }
 
@@ -228,6 +230,7 @@ class BridgeMockzillaConfig {
       isRelease: result[2]! as bool,
       localHostOnly: result[3]! as bool,
       logLevel: BridgeLogLevel.values[result[4]! as int],
+      releaseModeConfig: BridgeReleaseModeConfig.decode(result[5]! as List<Object?>),
     );
   }
 }
@@ -321,15 +324,15 @@ class _MockzillaHostApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return BridgeEndpointConfig.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return BridgeMockzillaConfig.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return BridgeMockzillaHttpResponse.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return BridgeMockzillaRuntimeParams.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return BridgeReleaseModeConfig.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -347,11 +350,9 @@ class MockzillaHostApi {
 
   static const MessageCodec<Object?> codec = _MockzillaHostApiCodec();
 
-  Future<BridgeMockzillaRuntimeParams> startServer(
-      BridgeMockzillaConfig arg_config) async {
+  Future<BridgeMockzillaRuntimeParams> startServer(BridgeMockzillaConfig arg_config) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.mockzilla_android.MockzillaHostApi.startServer',
-        codec,
+        'dev.flutter.pigeon.mockzilla_android.MockzillaHostApi.startServer', codec,
         binaryMessenger: _binaryMessenger);
     final List<Object?>? replyList =
         await channel.send(<Object?>[arg_config]) as List<Object?>?;
@@ -378,10 +379,10 @@ class MockzillaHostApi {
 
   Future<void> stopServer() async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-        'dev.flutter.pigeon.mockzilla_android.MockzillaHostApi.stopServer',
-        codec,
+        'dev.flutter.pigeon.mockzilla_android.MockzillaHostApi.stopServer', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -420,11 +421,11 @@ class _MockzillaFlutterApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return BridgeAuthHeader.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return BridgeMockzillaHttpRequest.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return BridgeMockzillaHttpResponse.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -437,33 +438,27 @@ abstract class MockzillaFlutterApi {
 
   bool endpointMatcher(BridgeMockzillaHttpRequest request, String key);
 
-  BridgeMockzillaHttpResponse defaultHandler(
-      BridgeMockzillaHttpRequest request, String key);
+  BridgeMockzillaHttpResponse defaultHandler(BridgeMockzillaHttpRequest request, String key);
 
-  BridgeMockzillaHttpResponse errorHandler(
-      BridgeMockzillaHttpRequest request, String key);
+  BridgeMockzillaHttpResponse errorHandler(BridgeMockzillaHttpRequest request, String key);
 
   Future<BridgeAuthHeader> generateAuthHeader();
 
-  void log(
-      BridgeLogLevel logLevel, String message, String tag, String? exception);
+  void log(BridgeLogLevel logLevel, String message, String tag, String? exception);
 
-  static void setup(MockzillaFlutterApi? api,
-      {BinaryMessenger? binaryMessenger}) {
+  static void setup(MockzillaFlutterApi? api, {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.endpointMatcher',
-          codec,
+          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.endpointMatcher', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.endpointMatcher was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.endpointMatcher was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeMockzillaHttpRequest? arg_request =
-              (args[0] as BridgeMockzillaHttpRequest?);
+          final BridgeMockzillaHttpRequest? arg_request = (args[0] as BridgeMockzillaHttpRequest?);
           assert(arg_request != null,
               'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.endpointMatcher was null, expected non-null BridgeMockzillaHttpRequest.');
           final String? arg_key = (args[1] as String?);
@@ -474,81 +469,71 @@ abstract class MockzillaFlutterApi {
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.defaultHandler',
-          codec,
+          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.defaultHandler', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.defaultHandler was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.defaultHandler was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeMockzillaHttpRequest? arg_request =
-              (args[0] as BridgeMockzillaHttpRequest?);
+          final BridgeMockzillaHttpRequest? arg_request = (args[0] as BridgeMockzillaHttpRequest?);
           assert(arg_request != null,
               'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.defaultHandler was null, expected non-null BridgeMockzillaHttpRequest.');
           final String? arg_key = (args[1] as String?);
           assert(arg_key != null,
               'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.defaultHandler was null, expected non-null String.');
           try {
-            final BridgeMockzillaHttpResponse output =
-                api.defaultHandler(arg_request!, arg_key!);
+            final BridgeMockzillaHttpResponse output = api.defaultHandler(arg_request!, arg_key!);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.errorHandler',
-          codec,
+          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.errorHandler', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.errorHandler was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.errorHandler was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeMockzillaHttpRequest? arg_request =
-              (args[0] as BridgeMockzillaHttpRequest?);
+          final BridgeMockzillaHttpRequest? arg_request = (args[0] as BridgeMockzillaHttpRequest?);
           assert(arg_request != null,
               'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.errorHandler was null, expected non-null BridgeMockzillaHttpRequest.');
           final String? arg_key = (args[1] as String?);
           assert(arg_key != null,
               'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.errorHandler was null, expected non-null String.');
           try {
-            final BridgeMockzillaHttpResponse output =
-                api.errorHandler(arg_request!, arg_key!);
+            final BridgeMockzillaHttpResponse output = api.errorHandler(arg_request!, arg_key!);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.generateAuthHeader',
-          codec,
+          'dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.generateAuthHeader', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
@@ -559,9 +544,8 @@ abstract class MockzillaFlutterApi {
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -575,10 +559,9 @@ abstract class MockzillaFlutterApi {
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.log was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.log was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeLogLevel? arg_logLevel =
-              args[0] == null ? null : BridgeLogLevel.values[args[0]! as int];
+          final BridgeLogLevel? arg_logLevel = args[0] == null ? null : BridgeLogLevel.values[args[0]! as int];
           assert(arg_logLevel != null,
               'Argument for dev.flutter.pigeon.mockzilla_android.MockzillaFlutterApi.log was null, expected non-null BridgeLogLevel.');
           final String? arg_message = (args[1] as String?);
@@ -593,9 +576,8 @@ abstract class MockzillaFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/FlutterMockzilla/mockzilla_ios/lib/src/api_utils.dart
+++ b/FlutterMockzilla/mockzilla_ios/lib/src/api_utils.dart
@@ -135,6 +135,7 @@ extension MockzillaConfigBridge on MockzillaConfig {
         isRelease: isRelease,
         localHostOnly: localHostOnly,
         logLevel: logLevel.toBridge(),
+        releaseModeConfig: releaseModeConfig.toBridge(),
       );
 }
 

--- a/FlutterMockzilla/mockzilla_ios/lib/src/messages.g.dart
+++ b/FlutterMockzilla/mockzilla_ios/lib/src/messages.g.dart
@@ -7,9 +7,7 @@ import 'dart:typed_data' show Float64List, Int32List, Int64List, Uint8List;
 
 import 'package:flutter/foundation.dart' show ReadBuffer, WriteBuffer;
 import 'package:flutter/services.dart';
-
-List<Object?> wrapResponse(
-    {Object? result, PlatformException? error, bool empty = false}) {
+List<Object?> wrapResponse({Object? result, PlatformException? error, bool empty = false}) {
   if (empty) {
     return <Object?>[];
   }
@@ -198,6 +196,7 @@ class BridgeMockzillaConfig {
     required this.isRelease,
     required this.localHostOnly,
     required this.logLevel,
+    required this.releaseModeConfig,
   });
 
   int port;
@@ -210,6 +209,8 @@ class BridgeMockzillaConfig {
 
   BridgeLogLevel logLevel;
 
+  BridgeReleaseModeConfig releaseModeConfig;
+
   Object encode() {
     return <Object?>[
       port,
@@ -217,6 +218,7 @@ class BridgeMockzillaConfig {
       isRelease,
       localHostOnly,
       logLevel.index,
+      releaseModeConfig.encode(),
     ];
   }
 
@@ -228,6 +230,7 @@ class BridgeMockzillaConfig {
       isRelease: result[2]! as bool,
       localHostOnly: result[3]! as bool,
       logLevel: BridgeLogLevel.values[result[4]! as int],
+      releaseModeConfig: BridgeReleaseModeConfig.decode(result[5]! as List<Object?>),
     );
   }
 }
@@ -321,15 +324,15 @@ class _MockzillaHostApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return BridgeEndpointConfig.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return BridgeMockzillaConfig.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return BridgeMockzillaHttpResponse.decode(readValue(buffer)!);
-      case 131:
+      case 131: 
         return BridgeMockzillaRuntimeParams.decode(readValue(buffer)!);
-      case 132:
+      case 132: 
         return BridgeReleaseModeConfig.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -347,8 +350,7 @@ class MockzillaHostApi {
 
   static const MessageCodec<Object?> codec = _MockzillaHostApiCodec();
 
-  Future<BridgeMockzillaRuntimeParams> startServer(
-      BridgeMockzillaConfig arg_config) async {
+  Future<BridgeMockzillaRuntimeParams> startServer(BridgeMockzillaConfig arg_config) async {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.mockzilla_ios.MockzillaHostApi.startServer', codec,
         binaryMessenger: _binaryMessenger);
@@ -379,7 +381,8 @@ class MockzillaHostApi {
     final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
         'dev.flutter.pigeon.mockzilla_ios.MockzillaHostApi.stopServer', codec,
         binaryMessenger: _binaryMessenger);
-    final List<Object?>? replyList = await channel.send(null) as List<Object?>?;
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
     if (replyList == null) {
       throw PlatformException(
         code: 'channel-error',
@@ -418,11 +421,11 @@ class _MockzillaFlutterApiCodec extends StandardMessageCodec {
   @override
   Object? readValueOfType(int type, ReadBuffer buffer) {
     switch (type) {
-      case 128:
+      case 128: 
         return BridgeAuthHeader.decode(readValue(buffer)!);
-      case 129:
+      case 129: 
         return BridgeMockzillaHttpRequest.decode(readValue(buffer)!);
-      case 130:
+      case 130: 
         return BridgeMockzillaHttpResponse.decode(readValue(buffer)!);
       default:
         return super.readValueOfType(type, buffer);
@@ -435,33 +438,27 @@ abstract class MockzillaFlutterApi {
 
   bool endpointMatcher(BridgeMockzillaHttpRequest request, String key);
 
-  BridgeMockzillaHttpResponse defaultHandler(
-      BridgeMockzillaHttpRequest request, String key);
+  BridgeMockzillaHttpResponse defaultHandler(BridgeMockzillaHttpRequest request, String key);
 
-  BridgeMockzillaHttpResponse errorHandler(
-      BridgeMockzillaHttpRequest request, String key);
+  BridgeMockzillaHttpResponse errorHandler(BridgeMockzillaHttpRequest request, String key);
 
   Future<BridgeAuthHeader> generateAuthHeader();
 
-  void log(
-      BridgeLogLevel logLevel, String message, String tag, String? exception);
+  void log(BridgeLogLevel logLevel, String message, String tag, String? exception);
 
-  static void setup(MockzillaFlutterApi? api,
-      {BinaryMessenger? binaryMessenger}) {
+  static void setup(MockzillaFlutterApi? api, {BinaryMessenger? binaryMessenger}) {
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.endpointMatcher',
-          codec,
+          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.endpointMatcher', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.endpointMatcher was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.endpointMatcher was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeMockzillaHttpRequest? arg_request =
-              (args[0] as BridgeMockzillaHttpRequest?);
+          final BridgeMockzillaHttpRequest? arg_request = (args[0] as BridgeMockzillaHttpRequest?);
           assert(arg_request != null,
               'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.endpointMatcher was null, expected non-null BridgeMockzillaHttpRequest.');
           final String? arg_key = (args[1] as String?);
@@ -472,81 +469,71 @@ abstract class MockzillaFlutterApi {
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.defaultHandler',
-          codec,
+          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.defaultHandler', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.defaultHandler was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.defaultHandler was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeMockzillaHttpRequest? arg_request =
-              (args[0] as BridgeMockzillaHttpRequest?);
+          final BridgeMockzillaHttpRequest? arg_request = (args[0] as BridgeMockzillaHttpRequest?);
           assert(arg_request != null,
               'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.defaultHandler was null, expected non-null BridgeMockzillaHttpRequest.');
           final String? arg_key = (args[1] as String?);
           assert(arg_key != null,
               'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.defaultHandler was null, expected non-null String.');
           try {
-            final BridgeMockzillaHttpResponse output =
-                api.defaultHandler(arg_request!, arg_key!);
+            final BridgeMockzillaHttpResponse output = api.defaultHandler(arg_request!, arg_key!);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.errorHandler',
-          codec,
+          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.errorHandler', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.errorHandler was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.errorHandler was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeMockzillaHttpRequest? arg_request =
-              (args[0] as BridgeMockzillaHttpRequest?);
+          final BridgeMockzillaHttpRequest? arg_request = (args[0] as BridgeMockzillaHttpRequest?);
           assert(arg_request != null,
               'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.errorHandler was null, expected non-null BridgeMockzillaHttpRequest.');
           final String? arg_key = (args[1] as String?);
           assert(arg_key != null,
               'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.errorHandler was null, expected non-null String.');
           try {
-            final BridgeMockzillaHttpResponse output =
-                api.errorHandler(arg_request!, arg_key!);
+            final BridgeMockzillaHttpResponse output = api.errorHandler(arg_request!, arg_key!);
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
     }
     {
       final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
-          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.generateAuthHeader',
-          codec,
+          'dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.generateAuthHeader', codec,
           binaryMessenger: binaryMessenger);
       if (api == null) {
         channel.setMessageHandler(null);
@@ -557,9 +544,8 @@ abstract class MockzillaFlutterApi {
             return wrapResponse(result: output);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }
@@ -573,10 +559,9 @@ abstract class MockzillaFlutterApi {
       } else {
         channel.setMessageHandler((Object? message) async {
           assert(message != null,
-              'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.log was null.');
+          'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.log was null.');
           final List<Object?> args = (message as List<Object?>?)!;
-          final BridgeLogLevel? arg_logLevel =
-              args[0] == null ? null : BridgeLogLevel.values[args[0]! as int];
+          final BridgeLogLevel? arg_logLevel = args[0] == null ? null : BridgeLogLevel.values[args[0]! as int];
           assert(arg_logLevel != null,
               'Argument for dev.flutter.pigeon.mockzilla_ios.MockzillaFlutterApi.log was null, expected non-null BridgeLogLevel.');
           final String? arg_message = (args[1] as String?);
@@ -591,9 +576,8 @@ abstract class MockzillaFlutterApi {
             return wrapResponse(empty: true);
           } on PlatformException catch (e) {
             return wrapResponse(error: e);
-          } catch (e) {
-            return wrapResponse(
-                error: PlatformException(code: 'error', message: e.toString()));
+          }          catch (e) {
+            return wrapResponse(error: PlatformException(code: 'error', message: e.toString()));
           }
         });
       }

--- a/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.dart
+++ b/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:mockzilla_platform_interface/mockzilla_platform_interface.dart';
 
 part 'models.freezed.dart';
 
@@ -129,6 +130,9 @@ class MockzillaConfig with _$MockzillaConfig {
 
     /// The level of logging that should be used by Mockzilla.
     @Default(LogLevel.info) LogLevel logLevel,
+
+    /// Used for additional configuration when [isRelease] is [true].
+    @Default(ReleaseModeConfig()) ReleaseModeConfig releaseModeConfig,
   }) = _MockzillaConfig;
 }
 

--- a/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.freezed.dart
+++ b/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.freezed.dart
@@ -136,9 +136,7 @@ class __$$MockzillaHttpRequestImplCopyWithImpl<$Res>
 class _$MockzillaHttpRequestImpl implements _MockzillaHttpRequest {
   const _$MockzillaHttpRequestImpl(
       {required this.uri,
-      final Map<String, String> headers = const {
-        "Content-Type": "application/json"
-      },
+      final Map<String, String> headers = const {},
       this.body = "",
       required this.method})
       : _headers = headers;
@@ -315,7 +313,9 @@ class __$$MockzillaHttpResponseImplCopyWithImpl<$Res>
 class _$MockzillaHttpResponseImpl implements _MockzillaHttpResponse {
   const _$MockzillaHttpResponseImpl(
       {this.statusCode = HttpStatus.ok,
-      final Map<String, String> headers = const {},
+      final Map<String, String> headers = const {
+        "Content-Type": "application/json"
+      },
       this.body = ""})
       : _headers = headers;
 
@@ -993,6 +993,9 @@ mixin _$MockzillaConfig {
   /// The level of logging that should be used by Mockzilla.
   LogLevel get logLevel => throw _privateConstructorUsedError;
 
+  /// Used for additional configuration when [isRelease] is [true].
+  ReleaseModeConfig get releaseModeConfig => throw _privateConstructorUsedError;
+
   @JsonKey(ignore: true)
   $MockzillaConfigCopyWith<MockzillaConfig> get copyWith =>
       throw _privateConstructorUsedError;
@@ -1009,7 +1012,10 @@ abstract class $MockzillaConfigCopyWith<$Res> {
       List<EndpointConfig> endpoints,
       bool isRelease,
       bool localHostOnly,
-      LogLevel logLevel});
+      LogLevel logLevel,
+      ReleaseModeConfig releaseModeConfig});
+
+  $ReleaseModeConfigCopyWith<$Res> get releaseModeConfig;
 }
 
 /// @nodoc
@@ -1030,6 +1036,7 @@ class _$MockzillaConfigCopyWithImpl<$Res, $Val extends MockzillaConfig>
     Object? isRelease = null,
     Object? localHostOnly = null,
     Object? logLevel = null,
+    Object? releaseModeConfig = null,
   }) {
     return _then(_value.copyWith(
       port: null == port
@@ -1052,7 +1059,19 @@ class _$MockzillaConfigCopyWithImpl<$Res, $Val extends MockzillaConfig>
           ? _value.logLevel
           : logLevel // ignore: cast_nullable_to_non_nullable
               as LogLevel,
+      releaseModeConfig: null == releaseModeConfig
+          ? _value.releaseModeConfig
+          : releaseModeConfig // ignore: cast_nullable_to_non_nullable
+              as ReleaseModeConfig,
     ) as $Val);
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $ReleaseModeConfigCopyWith<$Res> get releaseModeConfig {
+    return $ReleaseModeConfigCopyWith<$Res>(_value.releaseModeConfig, (value) {
+      return _then(_value.copyWith(releaseModeConfig: value) as $Val);
+    });
   }
 }
 
@@ -1069,7 +1088,11 @@ abstract class _$$MockzillaConfigImplCopyWith<$Res>
       List<EndpointConfig> endpoints,
       bool isRelease,
       bool localHostOnly,
-      LogLevel logLevel});
+      LogLevel logLevel,
+      ReleaseModeConfig releaseModeConfig});
+
+  @override
+  $ReleaseModeConfigCopyWith<$Res> get releaseModeConfig;
 }
 
 /// @nodoc
@@ -1088,6 +1111,7 @@ class __$$MockzillaConfigImplCopyWithImpl<$Res>
     Object? isRelease = null,
     Object? localHostOnly = null,
     Object? logLevel = null,
+    Object? releaseModeConfig = null,
   }) {
     return _then(_$MockzillaConfigImpl(
       port: null == port
@@ -1110,6 +1134,10 @@ class __$$MockzillaConfigImplCopyWithImpl<$Res>
           ? _value.logLevel
           : logLevel // ignore: cast_nullable_to_non_nullable
               as LogLevel,
+      releaseModeConfig: null == releaseModeConfig
+          ? _value.releaseModeConfig
+          : releaseModeConfig // ignore: cast_nullable_to_non_nullable
+              as ReleaseModeConfig,
     ));
   }
 }
@@ -1122,7 +1150,8 @@ class _$MockzillaConfigImpl implements _MockzillaConfig {
       final List<EndpointConfig> endpoints = const [],
       this.isRelease = false,
       this.localHostOnly = false,
-      this.logLevel = LogLevel.info})
+      this.logLevel = LogLevel.info,
+      this.releaseModeConfig = const ReleaseModeConfig()})
       : _endpoints = endpoints;
 
   /// The port that the Mockzilla should be available through.
@@ -1159,9 +1188,14 @@ class _$MockzillaConfigImpl implements _MockzillaConfig {
   @JsonKey()
   final LogLevel logLevel;
 
+  /// Used for additional configuration when [isRelease] is [true].
+  @override
+  @JsonKey()
+  final ReleaseModeConfig releaseModeConfig;
+
   @override
   String toString() {
-    return 'MockzillaConfig(port: $port, endpoints: $endpoints, isRelease: $isRelease, localHostOnly: $localHostOnly, logLevel: $logLevel)';
+    return 'MockzillaConfig(port: $port, endpoints: $endpoints, isRelease: $isRelease, localHostOnly: $localHostOnly, logLevel: $logLevel, releaseModeConfig: $releaseModeConfig)';
   }
 
   @override
@@ -1177,7 +1211,9 @@ class _$MockzillaConfigImpl implements _MockzillaConfig {
             (identical(other.localHostOnly, localHostOnly) ||
                 other.localHostOnly == localHostOnly) &&
             (identical(other.logLevel, logLevel) ||
-                other.logLevel == logLevel));
+                other.logLevel == logLevel) &&
+            (identical(other.releaseModeConfig, releaseModeConfig) ||
+                other.releaseModeConfig == releaseModeConfig));
   }
 
   @override
@@ -1187,7 +1223,8 @@ class _$MockzillaConfigImpl implements _MockzillaConfig {
       const DeepCollectionEquality().hash(_endpoints),
       isRelease,
       localHostOnly,
-      logLevel);
+      logLevel,
+      releaseModeConfig);
 
   @JsonKey(ignore: true)
   @override
@@ -1203,7 +1240,8 @@ abstract class _MockzillaConfig implements MockzillaConfig {
       final List<EndpointConfig> endpoints,
       final bool isRelease,
       final bool localHostOnly,
-      final LogLevel logLevel}) = _$MockzillaConfigImpl;
+      final LogLevel logLevel,
+      final ReleaseModeConfig releaseModeConfig}) = _$MockzillaConfigImpl;
 
   @override
 
@@ -1227,6 +1265,10 @@ abstract class _MockzillaConfig implements MockzillaConfig {
 
   /// The level of logging that should be used by Mockzilla.
   LogLevel get logLevel;
+  @override
+
+  /// Used for additional configuration when [isRelease] is [true].
+  ReleaseModeConfig get releaseModeConfig;
   @override
   @JsonKey(ignore: true)
   _$$MockzillaConfigImplCopyWith<_$MockzillaConfigImpl> get copyWith =>


### PR DESCRIPTION
- Removes `package` attribute in Android manifest in `mockzilla_android` that was causing errors during builds when using AGP 8.
- Adds back `releaseModeConfig` to `MockzillaConfig` to avoid needing to make a breaking change.