### PR TITLE
Bump Flutter package versions

### DIFF
--- a/FlutterMockzilla/mockzilla/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.1.1
+
+* Adds default value of `{"Content-Type": "application/json"}` for parameter `headers` in
+  `MockzillaHttpResponse`.
+* Bumps dependencies of federated plugins
+  * `mockzilla_platform_interface` from `^0.1.0` -> `^0.2.0`
+  * `mockzilla_android` from `^0.1.0` -> `^0.1.1`
+  * `mockzilla_ios` from `^0.1.0` -> `^0.1.1`
+
 ## 0.1.0
 
 * Initial open-source release.

--- a/FlutterMockzilla/mockzilla/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla/pubspec.yaml
@@ -18,9 +18,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mockzilla_platform_interface: 0.2.0
-  mockzilla_android: 0.1.1
-  mockzilla_ios: 0.1.1
+  mockzilla_platform_interface: ^0.2.0
+  mockzilla_android: ^0.1.1
+  mockzilla_ios: ^0.1.1
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla
 description: A solution for configuring and running a local HTTP server as part of a Flutter app.
-version: 1.0.0 # x-release-please-version
+version: 0.1.1 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues
@@ -18,9 +18,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mockzilla_platform_interface: ^0.1.0
-  mockzilla_android: ^0.1.0
-  mockzilla_ios: ^0.1.0
+  mockzilla_platform_interface: 0.2.0
+  mockzilla_android: 0.1.1
+  mockzilla_ios: 0.1.1
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla_android/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.1.1
+
+* Removes `package` attribute from AndroidManifest that was incompatible with AGP 8.
+* Fixes an issue where `MockzillaIos.startMockzilla()` was referring to a missing
+  field in `MockzillaConfig`.
+
 ## 0.1.0
 
 * Initial open-source release.

--- a/FlutterMockzilla/mockzilla_android/example/pubspec.lock
+++ b/FlutterMockzilla/mockzilla_android/example/pubspec.lock
@@ -95,26 +95,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -143,23 +143,24 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mockzilla_android:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.1"
   mockzilla_platform_interface:
     dependency: transitive
     description:
-      path: "../../mockzilla_platform_interface"
-      relative: true
-    source: path
+      name: mockzilla_platform_interface
+      sha256: cd78c78137af887f019ec6b223fa565306df7c27278fff2a47d39efea884f5fc
+      url: "https://pub.dev"
+    source: hosted
     version: "0.1.0"
   path:
     dependency: transitive
@@ -226,10 +227,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   vector_math:
     dependency: transitive
     description:
@@ -242,10 +243,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
 sdks:
-  dart: ">=3.2.0 <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/FlutterMockzilla/mockzilla_android/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla_android
 description: The Android implementation for the mockzilla plugin.
-version: 1.0.0 # x-release-please-version
+version: 0.1.1 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues

--- a/FlutterMockzilla/mockzilla_android/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_android/pubspec.yaml
@@ -27,7 +27,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  mockzilla_platform_interface: ^0.1.0
+  mockzilla_platform_interface: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla_ios/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla_ios/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Fixes an issue where `MockzillaIos.startMockzilla()` was referring to a missing
+field in `MockzillaConfig`.
+
 ## 0.1.0
 
 * Initial open-source release.

--- a/FlutterMockzilla/mockzilla_ios/example/pubspec.lock
+++ b/FlutterMockzilla/mockzilla_ios/example/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "1.0.0"
   mockzilla_platform_interface:
     dependency: transitive
     description:

--- a/FlutterMockzilla/mockzilla_ios/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla_ios
 description: The iOS implementation for the mockzilla plugin.
-version: 1.0.0 # x-release-please-version
+version: 0.1.1 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues
@@ -25,6 +25,10 @@ dev_dependencies:
     sdk: flutter
   pigeon: ^12.0.1
   flutter_lints: ^3.0.0
+
+dependency_overrides:
+  mockzilla_platform_interface:
+    path: ../mockzilla_platform_interface
 
 flutter:
   plugin:

--- a/FlutterMockzilla/mockzilla_ios/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ios/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mockzilla_platform_interface: ^0.1.0
+  mockzilla_platform_interface: ^0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla_ios/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ios/pubspec.yaml
@@ -26,10 +26,6 @@ dev_dependencies:
   pigeon: ^12.0.1
   flutter_lints: ^3.0.0
 
-dependency_overrides:
-  mockzilla_platform_interface:
-    path: ../mockzilla_platform_interface
-
 flutter:
   plugin:
     implements: mockzilla

--- a/FlutterMockzilla/mockzilla_platform_interface/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla_platform_interface/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 0.1.1
+## 0.2.0
 
 * Adds default value of `{"Content-Type": "application/json"}` for parameter `headers` in 
 `MockzillaHttpResponse`.
+* Removes generated `MockzillaConfig.releaseModeConfig` from platform interface.
+* Removes generated `MockzillaConfig.additionalLogWriters` from platform interface.
 
 ## 0.1.0
 

--- a/FlutterMockzilla/mockzilla_platform_interface/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Adds default value of `{"Content-Type": "application/json"}` for parameter `headers` in 
+`MockzillaHttpResponse`.
+
 ## 0.1.0
 
 * Initial open-source release.

--- a/FlutterMockzilla/mockzilla_platform_interface/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla_platform_interface
 description: A common interface for the mockzilla plugin.
-version: 0.1.1 # x-release-please-version
+version: 0.2.0 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues

--- a/FlutterMockzilla/mockzilla_platform_interface/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla_platform_interface
 description: A common interface for the mockzilla plugin.
-version: 1.0.0 # x-release-please-version
+version: 0.1.1 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues


### PR DESCRIPTION
- Bumps Flutter versions for publishing AGP 8 fix to pub.dev
  - `mockzilla_platform_interface` from `0.1.0` -> `0.2.0` (breaking)
  - `mockzilla_ios` from `0.1.0` -> `0.1.1`
  - `mockzilla_android` from `0.1.0` -> `0.1.1`
  - `mockzilla` from `0.1.0` -> `0.1.1`

The CI checks for this will likely fail until the packages are available on pub.dev, I would appreciate some eyes on this before publishing though. Hindsight is that this should have been done in the branches in which these features were added.