### PR TITLE
fix: remove polyfill.io

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -46,5 +46,4 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack

Site still works without it, so let's get rid of in case it comes back (DNS has been cut off by someone alrady)