### PR TITLE
Fix HTTP request mapping

### DIFF
--- a/FlutterMockzilla/mockzilla/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Updates example app to include request body in fetch packages request.
+
 ## 0.1.1
 
 * Adds default value of `{"Content-Type": "application/json"}` for parameter `headers` in

--- a/FlutterMockzilla/mockzilla/example/README.md
+++ b/FlutterMockzilla/mockzilla/example/README.md
@@ -1,8 +1,5 @@
 This Flutter app is an example of how to use the `mockzilla` plugin.
 
-> *Note*: The `mockzila` plugin is currently under development and as such, the interface is not 
-> yet stable. This example will be updated inline with interface changes.
-
 ## Getting started
 
 In order to download the required dependencies for this app, run the following command in the base 
@@ -13,7 +10,8 @@ flutter pub get
 ```
 
 This app uses the [freezed](https://pub.dev/packages/freezed) package for code generation of 
-immutable classes that contain utilities such as `==`, `hashCode`, and `copyWith`.
+immutable classes that contain utilities such as `==`, `hashCode`, and `copyWith`. It also uses 
+[retrofit](https://pub.dev/packages/retrofit) to generate HTTP Dio clients.
 
 In order to execute the code generation, run the following command in the base directory of this 
 app.

--- a/FlutterMockzilla/mockzilla/example/lib/engine/config/mockzilla_config.dart
+++ b/FlutterMockzilla/mockzilla/example/lib/engine/config/mockzilla_config.dart
@@ -24,8 +24,16 @@ final defaultResponse = MockzillaHttpResponse(
           description: "A pretty cool network mocking library.",
         ),
         Package(
-          name: "freezed",
-          description: "Code generation for immutable classes.",
+          name: "mockzilla_platform_interface",
+          description: "A common interface for the mockzilla plugin.",
+        ),
+        Package(
+          name: "mockzilla_android",
+          description: "The Android implementation for the mockzilla plugin.",
+        ),
+        Package(
+          name: "mockzilla_ios",
+          description: "The iOS implementation for the mockzilla plugin.",
         ),
       ],
     ).toJson(),

--- a/FlutterMockzilla/mockzilla/example/lib/engine/feature/packages/models.dart
+++ b/FlutterMockzilla/mockzilla/example/lib/engine/feature/packages/models.dart
@@ -5,6 +5,16 @@ part 'models.freezed.dart';
 part 'models.g.dart';
 
 @freezed
+class FetchPackagesRequest with _$FetchPackagesRequest {
+  const factory FetchPackagesRequest({
+    required String query,
+  }) = _FetchPackagesRequest;
+
+  factory FetchPackagesRequest.fromJson(Map<String, dynamic> json) =>
+      _$FetchPackagesRequestFromJson(json);
+}
+
+@freezed
 class FetchPackagesResponse with _$FetchPackagesResponse {
   const factory FetchPackagesResponse({
     required List<Package> packages,

--- a/FlutterMockzilla/mockzilla/example/lib/engine/feature/packages/packages_client.dart
+++ b/FlutterMockzilla/mockzilla/example/lib/engine/feature/packages/packages_client.dart
@@ -6,9 +6,9 @@ part 'packages_client.g.dart';
 
 @RestApi(baseUrl: "http://localhost:8080/local-mock/")
 abstract class PackagesClient {
-
   factory PackagesClient(Dio dio, {String baseUrl}) = _PackagesClient;
 
   @GET("/packages")
-  Future<FetchPackagesResponse> fetchPackages();
+  Future<FetchPackagesResponse> fetchPackages(
+      @Body() FetchPackagesRequest request);
 }

--- a/FlutterMockzilla/mockzilla/example/lib/main.dart
+++ b/FlutterMockzilla/mockzilla/example/lib/main.dart
@@ -37,7 +37,9 @@ class PackagesList extends StatefulWidget {
 }
 
 class _PackagesListState extends State<PackagesList> {
-  final _packagesClient = PackagesClient(Dio());
+  final _packagesClient = PackagesClient(
+    Dio(BaseOptions(contentType: "application/json")),
+  );
   late Future<FetchPackagesResponse> _future;
 
   @override
@@ -48,7 +50,9 @@ class _PackagesListState extends State<PackagesList> {
 
   fetchPackages() {
     setState(() {
-      _future = _packagesClient.fetchPackages();
+      _future = _packagesClient.fetchPackages(
+        const FetchPackagesRequest(query: "mockzilla"),
+      );
     });
   }
 

--- a/FlutterMockzilla/mockzilla/example/pubspec.lock
+++ b/FlutterMockzilla/mockzilla/example/pubspec.lock
@@ -393,31 +393,31 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.1.2"
   mockzilla_android:
     dependency: transitive
     description:
       name: mockzilla_android
-      sha256: "797b4382629c5ea4542f8ed5ce62355d95aa6f0cc23772f8e1fd322bb3ef221a"
+      sha256: "278866fb050030d6d6e6d62d11aafaa0acdc772c3fa6e68d93e0575db0f0261e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.1"
   mockzilla_ios:
     dependency: transitive
     description:
       name: mockzilla_ios
-      sha256: ff85ff677977d88acd7011475489b106413d209f7a83938e23d911d53d96f7a0
+      sha256: "4148f43ac933d2485268130c61fd0a6e726b816424a9a31441260cc659b181cf"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.1"
   mockzilla_platform_interface:
     dependency: transitive
     description:
       name: mockzilla_platform_interface
-      sha256: cd78c78137af887f019ec6b223fa565306df7c27278fff2a47d39efea884f5fc
+      sha256: "64157655d3a97cfdfcccd26b84ae4a17bf4d11e999c9547c1b484ce181949d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   package_config:
     dependency: transitive
     description:

--- a/FlutterMockzilla/mockzilla/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla
 description: A solution for configuring and running a local HTTP server as part of a Flutter app.
-version: 0.1.1 # x-release-please-version
+version: 0.1.2 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues

--- a/FlutterMockzilla/mockzilla_android/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.2
+
+* Fixes an issue where HTTP request body was not passed from native models to Dart 
+[#172](https://github.com/Apadmi-Engineering/Mockzilla/issues/172).
+
 ## 0.1.1
 
 * Removes `package` attribute from AndroidManifest that was incompatible with AGP 8.

--- a/FlutterMockzilla/mockzilla_android/example/pubspec.lock
+++ b/FlutterMockzilla/mockzilla_android/example/pubspec.lock
@@ -153,15 +153,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.1"
+    version: "0.1.2"
   mockzilla_platform_interface:
     dependency: transitive
     description:
       name: mockzilla_platform_interface
-      sha256: cd78c78137af887f019ec6b223fa565306df7c27278fff2a47d39efea884f5fc
+      sha256: "64157655d3a97cfdfcccd26b84ae4a17bf4d11e999c9547c1b484ce181949d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   path:
     dependency: transitive
     description:

--- a/FlutterMockzilla/mockzilla_android/lib/src/api_utils.dart
+++ b/FlutterMockzilla/mockzilla_android/lib/src/api_utils.dart
@@ -31,6 +31,7 @@ extension BridgeMockzillaHttpRequestBridge on BridgeMockzillaHttpRequest {
         headers: Map.fromEntries(
           headers.entries.whereType<MapEntry<String, String>>(),
         ),
+        body: body,
         method: method.toDart(),
       );
 }

--- a/FlutterMockzilla/mockzilla_android/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla_android
 description: The Android implementation for the mockzilla plugin.
-version: 0.1.1 # x-release-please-version
+version: 0.1.2 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues

--- a/FlutterMockzilla/mockzilla_ios/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla_ios/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 0.1.2
 
 * Fixes an issue where HTTP request body was not passed from native models to Dart
-  [#172](https://github.com/Apadmi-Engineering/Mockzilla/issues/172).## 0.1.1
+  [#172](https://github.com/Apadmi-Engineering/Mockzilla/issues/172).
+
+## 0.1.1
 
 * Fixes an issue where `MockzillaIos.startMockzilla()` was referring to a missing
 field in `MockzillaConfig`.

--- a/FlutterMockzilla/mockzilla_ios/CHANGELOG.md
+++ b/FlutterMockzilla/mockzilla_ios/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.1.1
+## 0.1.2
+
+* Fixes an issue where HTTP request body was not passed from native models to Dart
+  [#172](https://github.com/Apadmi-Engineering/Mockzilla/issues/172).## 0.1.1
 
 * Fixes an issue where `MockzillaIos.startMockzilla()` was referring to a missing
 field in `MockzillaConfig`.

--- a/FlutterMockzilla/mockzilla_ios/example/pubspec.lock
+++ b/FlutterMockzilla/mockzilla_ios/example/pubspec.lock
@@ -176,15 +176,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.0.0"
+    version: "0.1.2"
   mockzilla_platform_interface:
     dependency: transitive
     description:
       name: mockzilla_platform_interface
-      sha256: cd78c78137af887f019ec6b223fa565306df7c27278fff2a47d39efea884f5fc
+      sha256: "64157655d3a97cfdfcccd26b84ae4a17bf4d11e999c9547c1b484ce181949d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.2.0"
   path:
     dependency: transitive
     description:

--- a/FlutterMockzilla/mockzilla_ios/lib/src/api_utils.dart
+++ b/FlutterMockzilla/mockzilla_ios/lib/src/api_utils.dart
@@ -31,6 +31,7 @@ extension BridgeMockzillaHttpRequestBridge on BridgeMockzillaHttpRequest {
         headers: Map.fromEntries(
           headers.entries.whereType<MapEntry<String, String>>(),
         ),
+        body: body,
         method: method.toDart(),
       );
 }

--- a/FlutterMockzilla/mockzilla_ios/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mockzilla_ios
 description: The iOS implementation for the mockzilla plugin.
-version: 0.1.1 # x-release-please-version
+version: 0.1.2 # x-release-please-version
 homepage: https://apadmi-engineering.github.io/Mockzilla/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues


### PR DESCRIPTION
- Fixes mapping of HTTP requests from bridge classes to Dart-side classes in `mockzilla_android` and `mockzilla_ios` (fixes #172 ).
  - Previously the `body` was omitted.
- Updates example app to include body in HTTP request.