### PR TITLE
Add basic JSON validation functionality to editor

### DIFF
--- a/mockzilla-management-ui/common/build.gradle.kts
+++ b/mockzilla-management-ui/common/build.gradle.kts
@@ -32,6 +32,9 @@ kotlin {
             /* Coroutines */
             implementation(libs.kotlinx.coroutines.core)
 
+            /* JSON */
+            implementation(libs.kotlinx.serialization.json)
+
             /* Mockzilla Management */
             implementation(project(":mockzilla-management"))
 

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/jsoneditor/JsonEditor.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/jsoneditor/JsonEditor.kt
@@ -1,0 +1,30 @@
+package com.apadmi.mockzilla.desktop.engine.jsoneditor
+
+import kotlinx.serialization.json.Json
+
+// Ideally we should have the Mockzilla app tell the management UI if trailing commas
+// or comments are allowed for JSON responses so we can match the application's validation
+private val jsonConfiguration = Json
+
+class JsonEditor(
+    private val body: String
+) {
+    fun isValidJson(): Boolean = try {
+        jsonConfiguration.parseToJsonElement(body)
+        true
+    } catch (error: Throwable) {
+        false
+    }
+
+    fun parseError(): String? {
+        if (body.isBlank()) {
+            return null
+        }
+        return try {
+            jsonConfiguration.parseToJsonElement(body)
+            null
+        } catch (error: Throwable) {
+            error.message
+        }
+    }
+}

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/i18n/En.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/i18n/En.kt
@@ -82,6 +82,7 @@ val EnStrings = Strings(
                     "Text"
                 }
             },
+            invalidJson = "Invalid JSON",
             failOptionsLabel = "User Error Response:",
             failLabel = { shouldFail: Boolean? ->
                 when (shouldFail) {

--- a/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/i18n/Strings.kt
+++ b/mockzilla-management-ui/common/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/i18n/Strings.kt
@@ -176,6 +176,7 @@ data class Strings(
          * @property bodyUnset
          * @property delayLabel
          * @property jsonEditingLabel
+         * @property invalidJson
          * @property failOptionsLabel
          * @property failLabel
          * @property responseDelay
@@ -212,6 +213,7 @@ data class Strings(
             val bodyUnset: String,
             val delayLabel: String,
             val jsonEditingLabel: (Boolean) -> String,
+            val invalidJson: String,
             val failOptionsLabel: String,
             val failLabel: (Boolean?) -> String,
             val responseDelay: String,

--- a/mockzilla-management-ui/common/src/desktopTest/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsViewModelTests.kt
+++ b/mockzilla-management-ui/common/src/desktopTest/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsViewModelTests.kt
@@ -176,8 +176,8 @@ class EndpointDetailsViewModelTests : CoroutineTest() {
                 errorHeaders = null,
                 fail = null,
                 delayMillis = null,
-                jsonEditingDefault = true,
-                jsonEditingError = true,
+                jsonEditingDefault = false,
+                jsonEditingError = false,
                 presets = presets,
             ),
             initialState


### PR DESCRIPTION
Adds basic JSON validation functionality to the editor. The error messages are just the output of kotlinx.serialization so aren't great but this is still an improvement over no error message in the web portal. Of course if the JSON is valid but doesn't meet the required schema for the app then requests will still fail but the Mockzilla management UI doesn’t have any way to know about this. Future work might want to let the app tell the management UI if its JSON endpoints allow comments or trailing commas so the validation in the editor can match on a per app/endpoint basis.

<img width="441" alt="Screenshot 2024-08-14 at 14 53 43" src="https://github.com/user-attachments/assets/c8b16650-5c9a-437e-9e12-7d323769c8a5">
<img width="441" alt="Screenshot 2024-08-14 at 14 53 52" src="https://github.com/user-attachments/assets/75ecc009-1608-494d-8b8f-4b6a75d13091">
<img width="441" alt="Screenshot 2024-08-14 at 14 54 11" src="https://github.com/user-attachments/assets/d9d9685c-bdc9-4942-bf69-8d78e21e5857">
