### PR TITLE
Automate publishing to pub.dev

### DIFF
--- a/.github/workflows/action_deploy_flutter.yml
+++ b/.github/workflows/action_deploy_flutter.yml
@@ -1,0 +1,15 @@
+name: Publish to `mockzilla` pub.dev
+
+on:
+  push:
+    tags:
+    - 'flutter_mockzilla-[0-9]+.[0-9]+.[0-9]+*'
+
+# Publish using the reusable workflow from dart-lang.
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: FlutterMockzilla/mockzilla

--- a/.github/workflows/action_deploy_flutter.yml
+++ b/.github/workflows/action_deploy_flutter.yml
@@ -13,3 +13,4 @@ jobs:
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: FlutterMockzilla/mockzilla
+      environment: pub.dev

--- a/.github/workflows/action_deploy_flutter.yml
+++ b/.github/workflows/action_deploy_flutter.yml
@@ -3,7 +3,7 @@ name: Publish to `mockzilla` pub.dev
 on:
   push:
     tags:
-    - 'flutter_mockzilla-[0-9]+.[0-9]+.[0-9]+*'
+    - 'flutter_mockzilla-v[0-9]+.[0-9]+.[0-9]+*'
 
 # Publish using the reusable workflow from dart-lang.
 jobs:

--- a/.github/workflows/action_deploy_flutter_android.yml
+++ b/.github/workflows/action_deploy_flutter_android.yml
@@ -3,7 +3,7 @@ name: Publish to `mockzilla_android` pub.dev
 on:
   push:
     tags:
-    - 'flutter_mockzilla_android-[0-9]+.[0-9]+.[0-9]+*'
+    - 'flutter_mockzilla_android-v[0-9]+.[0-9]+.[0-9]+*'
 
 # Publish using the reusable workflow from dart-lang.
 jobs:

--- a/.github/workflows/action_deploy_flutter_android.yml
+++ b/.github/workflows/action_deploy_flutter_android.yml
@@ -1,0 +1,15 @@
+name: Publish to `mockzilla_android` pub.dev
+
+on:
+  push:
+    tags:
+    - 'flutter_mockzilla_android-[0-9]+.[0-9]+.[0-9]+*'
+
+# Publish using the reusable workflow from dart-lang.
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: FlutterMockzilla/mockzilla_android

--- a/.github/workflows/action_deploy_flutter_android.yml
+++ b/.github/workflows/action_deploy_flutter_android.yml
@@ -13,3 +13,4 @@ jobs:
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: FlutterMockzilla/mockzilla_android
+      environment: pub.dev

--- a/.github/workflows/action_deploy_flutter_ios.yml
+++ b/.github/workflows/action_deploy_flutter_ios.yml
@@ -1,0 +1,15 @@
+name: Publish to `mockzilla_ios` pub.dev
+
+on:
+  push:
+    tags:
+    - 'flutter_mockzilla_ios-[0-9]+.[0-9]+.[0-9]+*'
+
+# Publish using the reusable workflow from dart-lang.
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: FlutterMockzilla/mockzilla_ios

--- a/.github/workflows/action_deploy_flutter_ios.yml
+++ b/.github/workflows/action_deploy_flutter_ios.yml
@@ -3,7 +3,7 @@ name: Publish to `mockzilla_ios` pub.dev
 on:
   push:
     tags:
-    - 'flutter_mockzilla_ios-[0-9]+.[0-9]+.[0-9]+*'
+    - 'flutter_mockzilla_ios-v[0-9]+.[0-9]+.[0-9]+*'
 
 # Publish using the reusable workflow from dart-lang.
 jobs:

--- a/.github/workflows/action_deploy_flutter_ios.yml
+++ b/.github/workflows/action_deploy_flutter_ios.yml
@@ -13,3 +13,4 @@ jobs:
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: FlutterMockzilla/mockzilla_ios
+      environment: pub.dev

--- a/.github/workflows/action_deploy_flutter_platform_interface.yml
+++ b/.github/workflows/action_deploy_flutter_platform_interface.yml
@@ -13,3 +13,4 @@ jobs:
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
     with:
       working-directory: FlutterMockzilla/mockzilla_platform_interface
+      environment: pub.dev

--- a/.github/workflows/action_deploy_flutter_platform_interface.yml
+++ b/.github/workflows/action_deploy_flutter_platform_interface.yml
@@ -1,0 +1,15 @@
+name: Publish `mockzilla_platform_interface` to pub.dev
+
+on:
+  push:
+    tags:
+    - 'flutter_mockzilla_platform_interface-[0-9]+.[0-9]+.[0-9]+*'
+
+# Publish using the reusable workflow from dart-lang.
+jobs:
+  publish:
+    permissions:
+      id-token: write
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    with:
+      working-directory: FlutterMockzilla/mockzilla_platform_interface

--- a/.github/workflows/action_deploy_flutter_platform_interface.yml
+++ b/.github/workflows/action_deploy_flutter_platform_interface.yml
@@ -3,7 +3,7 @@ name: Publish `mockzilla_platform_interface` to pub.dev
 on:
   push:
     tags:
-    - 'flutter_mockzilla_platform_interface-[0-9]+.[0-9]+.[0-9]+*'
+    - 'flutter_mockzilla_platform_interface-v[0-9]+.[0-9]+.[0-9]+*'
 
 # Publish using the reusable workflow from dart-lang.
 jobs:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "release-type": "simple",
+  "separate-pull-requests": true,
   "packages": {
     "mockzilla": {
       "component": "mockzilla",
@@ -14,20 +15,20 @@
       "extra-files": ["build.gradle.kts"]
     },
     "FlutterMockzilla/mockzilla": {
-      "component": "flutter-mockzilla-mockzilla",
-      "extra-files": ["pubspec.yaml"]
+      "component": "flutter_mockzilla",
+      "release-type": "dart"
     },
     "FlutterMockzilla/mockzilla_platform_interface": {
-      "component": "flutter-mockzilla-platform-interface",
-      "extra-files": ["pubspec.yaml"]
+      "component": "flutter_mockzilla_platform_interface",
+      "release-type": "dart"
     },
     "FlutterMockzilla/mockzilla_android": {
-      "component": "flutter-mockzilla-android",
-      "extra-files": ["pubspec.yaml"]
+      "component": "flutter_mockzilla_android",
+      "release-type": "dart"
     },
     "FlutterMockzilla/mockzilla_ios": {
-      "component": "flutter-mockzilla-ios",
-      "extra-files": ["pubspec.yaml"]
+      "component": "flutter_mockzilla_ios",
+      "release-type": "dart"
     },
     "mockzilla-management-ui": {
       "component": "mockzilla-management-ui",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,26 +13,21 @@
       "component": "mockzilla-management",
       "extra-files": ["build.gradle.kts"]
     },
-    "FlutterMockzilla": {
-      "component": "flutter-mockzilla",
-      "extra-files": [
-        {
-          "type": "generic",
-          "path": "mockzilla/pubspec.yaml"
-        },
-        {
-          "type": "generic",
-          "path": "mockzilla_android/pubspec.yaml"
-        },
-        {
-          "type": "generic",
-          "path": "mockzilla_ios/pubspec.yaml"
-        },
-        {
-          "type": "generic",
-          "path": "mockzilla_platform_interface/pubspec.yaml"
-        }
-      ]
+    "FlutterMockzilla/mockzilla": {
+      "component": "flutter-mockzilla-mockzilla",
+      "extra-files": ["pubspec.yaml"]
+    },
+    "FlutterMockzilla/mockzilla_platform_interface": {
+      "component": "flutter-mockzilla-platform-interface",
+      "extra-files": ["pubspec.yaml"]
+    },
+    "FlutterMockzilla/mockzilla_android": {
+      "component": "flutter-mockzilla-android",
+      "extra-files": ["pubspec.yaml"]
+    },
+    "FlutterMockzilla/mockzilla_ios": {
+      "component": "flutter-mockzilla-ios",
+      "extra-files": ["pubspec.yaml"]
     },
     "mockzilla-management-ui": {
       "component": "mockzilla-management-ui",


### PR DESCRIPTION
- Configures release-please to use separate pull requests for packages
  - Allows for de-coupling releases
- Configures release-please to track Flutter packages
- Adds GitHub Actions steps to publish to pub.dev upon tag push
  - The packages still need to be configured on pub.dev to allow automated publishing, will do so once this PR is merge and the GitHub actions environment has been setup.