### PR TITLE
Flutter v1 docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,8 @@ All work is tracked using Github Issues. Before starting please ensure you creat
 
 ## Write your code!
 
+For guidance on contributing to the Flutter packages, please checkout the [Flutter README](https://github.com/Apadmi-Engineering/Mockzilla/tree/develop/FlutterMockzilla).
+
 1. Checkout the tests. The library is setup with TDD in mind, we recommend writing your tests first!
 2. Implement your feature/bugfix!
 

--- a/FlutterMockzilla/README.md
+++ b/FlutterMockzilla/README.md
@@ -1,6 +1,31 @@
 # Flutter Mockzilla
 
-This is the root directory for all the Flutter packages in Mockzilla.
+The Mockzilla Flutter plugin package is implemented as a [federated plugin package](https://docs.flutter.dev/packages-and-plugins/developing-packages#federated-plugins). It calls through to the KMM library utilising [Pigeon](https://pub.dev/packages/pigeon) platform channels; this decision was made to ensure that the Flutter package remains aligned with the underlying KMM package but also removes the complexity developers face with method channels.
 
-The Flutter package is implemented as a [federated plugin package](https://docs.flutter.dev/packages-and-plugins/developing-packages#federated-plugins) 
-which separates the interfaces from each platform implementation. To manage these packages, the repository uses [melos](https://melos.invertase.dev/).
+## Handling package inter-dependencies
+
+To handle the package inter-dependencies and minimise boilerplate in continuous integration scripts, the repository utilises [melos](https://melos.invertase.dev/). Once you have checked out the repository, install Melos with the following command.
+
+```shell
+dart pub global activate melos
+```
+
+Once installed, `cd` into the `FlutterMockzilla/` directory and run the following command, which will override package inter-dependencies with the versions on your local machine.
+
+```shell
+melos bootstrap
+```
+
+## Model generation
+
+Immutable model classes are generated using the freezed package, included in the generated classes are utility methods such as `copyWith()` and `==`. When editing model class definitions, make sure to run the following command to update the generated code.
+
+```shell
+dart run build_runner build
+```
+
+Alternatively, start a background process to watch the project files and automatically update the generated code in response to changes.
+
+```shell
+dart run build_runner watch
+```

--- a/FlutterMockzilla/mockzilla/example/lib/engine/config/mockzilla_config.dart
+++ b/FlutterMockzilla/mockzilla/example/lib/engine/config/mockzilla_config.dart
@@ -10,6 +10,7 @@ final mockzillaConfig = const MockzillaConfig().addEndpoint(
         request.uri.endsWith("packages") && request.method == HttpMethod.get,
     defaultHandler: (_) => defaultResponse,
     errorHandler: (_) => errorResponse,
+    shouldFail: true,
   ),
 );
 

--- a/FlutterMockzilla/mockzilla/lib/src/mockzilla.dart
+++ b/FlutterMockzilla/mockzilla/lib/src/mockzilla.dart
@@ -1,9 +1,11 @@
 import 'package:mockzilla_platform_interface/mockzilla_platform_interface.dart';
 
 abstract class Mockzilla {
+  /// Starts the Mockzilla server with the given configuration.
   static Future<void> startMockzilla(MockzillaConfig config) =>
       MockzillaPlatform.instance.startMockzilla(config);
 
+  /// Stops the Mockzilla server.
   static Future<void> stopMockzilla() =>
       MockzillaPlatform.instance.stopMockzilla();
 }

--- a/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.dart
+++ b/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:mockzilla_platform_interface/mockzilla_platform_interface.dart';
 
 part 'models.freezed.dart';
 
@@ -41,7 +40,10 @@ class MockzillaHttpResponse with _$MockzillaHttpResponse {
   /// Created and returned by an endpoint handler in response to an incoming
   /// HTTP request.
   const factory MockzillaHttpResponse({
+    /// The HTTP status to use for the response, defaults to 200 - OK.
     @Default(HttpStatus.ok) int statusCode,
+    /// The response headers, defaults a single `Content-Type` header with a
+    /// value of `application/json`.
     @Default({"Content-Type": "application/json"}) Map<String, String> headers,
     @Default("") String body,
   }) = _MockzillaHttpResponse;
@@ -49,6 +51,8 @@ class MockzillaHttpResponse with _$MockzillaHttpResponse {
 
 @freezed
 class DashboardOverridePreset with _$DashboardOverridePreset {
+  /// Definition for a preset response that can be selected in the desktop
+  /// management app.
   const factory DashboardOverridePreset({
     required String name,
     required String? description,
@@ -58,6 +62,8 @@ class DashboardOverridePreset with _$DashboardOverridePreset {
 
 @freezed
 class DashboardOptionsConfig with _$DashboardOptionsConfig {
+  /// A collection of preset responses from an endpoint that can be selected in
+  /// the desktop management app.
   const factory DashboardOptionsConfig({
     @Default([]) List<DashboardOverridePreset> successPresets,
     @Default([]) List<DashboardOverridePreset> errorPresets,
@@ -68,24 +74,28 @@ class DashboardOptionsConfig with _$DashboardOptionsConfig {
 class EndpointConfig with _$EndpointConfig {
   const EndpointConfig._();
 
-  /// This configuration defines how Mockzilla should deal with a subset of
-  /// requests such as configuring the response and meta-data such as the
-  /// latency and failure rate.
+  /// Configuration for an endpoint including how requests should be handled
+  /// and desktop app presets.
   ///
   /// Please see [https://apadmi-engineering.github.io/Mockzilla/endpoints/]()
   /// for more information.
   const factory EndpointConfig({
     required String name,
+
+    /// Identifier for this endpoint, defaults to [name].
     String? customKey,
 
     /// Whether the Mockzilla server should return an artificial error for a
-    /// request to this endpoint.
+    /// request to this endpoint. Defaults to [false].
     @Default(false) bool shouldFail,
 
-    /// Optional, the artificial delay that Mockzilla should apply to responses
-    /// to simulate latency.
+    /// The artificial delay that Mockzilla should apply to responses
+    /// to simulate latency. Defaults to 100ms.
     @Default(Duration(milliseconds: 100)) Duration delay,
 
+    /// Incrementing this will indicate a breaking change has been
+    /// made to this endpoint and will invalidate any cached data on the host
+    /// device without intervention by the user. Defaults to 1.
     @Default(1) int versionCode,
 
     /// Used to determine whether a particular `request` should be evaluated by
@@ -97,13 +107,13 @@ class EndpointConfig with _$EndpointConfig {
     @Default(DashboardOptionsConfig()) DashboardOptionsConfig dashboardOptionsConfig,
 
     /// This function is called when a network request is made to this endpoint,
-    /// note that if an error is being returned due to `failureProbability`
-    /// then `errorHandler` is used instead.
+    /// note that if an error is being returned due to [shouldFail] then
+    /// `errorHandler` is used instead.
     required MockzillaHttpResponse Function(MockzillaHttpRequest request)
         defaultHandler,
 
     /// This function is called when, in response to a network request, the
-    /// server returns an error due to`failureProbability`.
+    /// server returns an error due to [shouldFail].
     required MockzillaHttpResponse Function(MockzillaHttpRequest request)
         errorHandler,
   }) = _EndpointConfig;
@@ -150,8 +160,8 @@ class MockzillaConfig with _$MockzillaConfig {
     /// Used for additional configuration when [isRelease] is [true].
     @Default(ReleaseModeConfig()) ReleaseModeConfig releaseModeConfig,
 
-    /// Whether devices running Mockzilla are discoverable through the desktop
-    /// management UI.
+    /// Whether devices running Mockzilla are discoverable on the local network
+    /// through the desktop management app.
     @Default(true) bool isNetworkDiscoveryEnabled,
   }) = _MockzillaConfig;
 }

--- a/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.freezed.dart
+++ b/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.freezed.dart
@@ -221,7 +221,11 @@ abstract class _MockzillaHttpRequest implements MockzillaHttpRequest {
 
 /// @nodoc
 mixin _$MockzillaHttpResponse {
+  /// The HTTP status to use for the response, defaults to 200 - OK.
   int get statusCode => throw _privateConstructorUsedError;
+
+  /// The response headers, defaults a single `Content-Type` header with a
+  /// value of `application/json`.
   Map<String, String> get headers => throw _privateConstructorUsedError;
   String get body => throw _privateConstructorUsedError;
 
@@ -336,10 +340,17 @@ class _$MockzillaHttpResponseImpl implements _MockzillaHttpResponse {
       this.body = ""})
       : _headers = headers;
 
+  /// The HTTP status to use for the response, defaults to 200 - OK.
   @override
   @JsonKey()
   final int statusCode;
+
+  /// The response headers, defaults a single `Content-Type` header with a
+  /// value of `application/json`.
   final Map<String, String> _headers;
+
+  /// The response headers, defaults a single `Content-Type` header with a
+  /// value of `application/json`.
   @override
   @JsonKey()
   Map<String, String> get headers {
@@ -388,8 +399,12 @@ abstract class _MockzillaHttpResponse implements MockzillaHttpResponse {
       final Map<String, String> headers,
       final String body}) = _$MockzillaHttpResponseImpl;
 
+  /// The HTTP status to use for the response, defaults to 200 - OK.
   @override
   int get statusCode;
+
+  /// The response headers, defaults a single `Content-Type` header with a
+  /// value of `application/json`.
   @override
   Map<String, String> get headers;
   @override
@@ -773,15 +788,21 @@ abstract class _DashboardOptionsConfig implements DashboardOptionsConfig {
 /// @nodoc
 mixin _$EndpointConfig {
   String get name => throw _privateConstructorUsedError;
+
+  /// Identifier for this endpoint, defaults to [name].
   String? get customKey => throw _privateConstructorUsedError;
 
   /// Whether the Mockzilla server should return an artificial error for a
-  /// request to this endpoint.
+  /// request to this endpoint. Defaults to [false].
   bool get shouldFail => throw _privateConstructorUsedError;
 
-  /// Optional, the artificial delay that Mockzilla should apply to responses
-  /// to simulate latency.
+  /// The artificial delay that Mockzilla should apply to responses
+  /// to simulate latency. Defaults to 100ms.
   Duration get delay => throw _privateConstructorUsedError;
+
+  /// Incrementing this will indicate a breaking change has been
+  /// made to this endpoint and will invalidate any cached data on the host
+  /// device without intervention by the user. Defaults to 1.
   int get versionCode => throw _privateConstructorUsedError;
 
   /// Used to determine whether a particular `request` should be evaluated by
@@ -795,13 +816,13 @@ mixin _$EndpointConfig {
       throw _privateConstructorUsedError;
 
   /// This function is called when a network request is made to this endpoint,
-  /// note that if an error is being returned due to `failureProbability`
-  /// then `errorHandler` is used instead.
+  /// note that if an error is being returned due to [shouldFail] then
+  /// `errorHandler` is used instead.
   MockzillaHttpResponse Function(MockzillaHttpRequest) get defaultHandler =>
       throw _privateConstructorUsedError;
 
   /// This function is called when, in response to a network request, the
-  /// server returns an error due to`failureProbability`.
+  /// server returns an error due to [shouldFail].
   MockzillaHttpResponse Function(MockzillaHttpRequest) get errorHandler =>
       throw _privateConstructorUsedError;
 
@@ -1013,20 +1034,26 @@ class _$EndpointConfigImpl extends _EndpointConfig {
 
   @override
   final String name;
+
+  /// Identifier for this endpoint, defaults to [name].
   @override
   final String? customKey;
 
   /// Whether the Mockzilla server should return an artificial error for a
-  /// request to this endpoint.
+  /// request to this endpoint. Defaults to [false].
   @override
   @JsonKey()
   final bool shouldFail;
 
-  /// Optional, the artificial delay that Mockzilla should apply to responses
-  /// to simulate latency.
+  /// The artificial delay that Mockzilla should apply to responses
+  /// to simulate latency. Defaults to 100ms.
   @override
   @JsonKey()
   final Duration delay;
+
+  /// Incrementing this will indicate a breaking change has been
+  /// made to this endpoint and will invalidate any cached data on the host
+  /// device without intervention by the user. Defaults to 1.
   @override
   @JsonKey()
   final int versionCode;
@@ -1043,13 +1070,13 @@ class _$EndpointConfigImpl extends _EndpointConfig {
   final DashboardOptionsConfig dashboardOptionsConfig;
 
   /// This function is called when a network request is made to this endpoint,
-  /// note that if an error is being returned due to `failureProbability`
-  /// then `errorHandler` is used instead.
+  /// note that if an error is being returned due to [shouldFail] then
+  /// `errorHandler` is used instead.
   @override
   final MockzillaHttpResponse Function(MockzillaHttpRequest) defaultHandler;
 
   /// This function is called when, in response to a network request, the
-  /// server returns an error due to`failureProbability`.
+  /// server returns an error due to [shouldFail].
   @override
   final MockzillaHttpResponse Function(MockzillaHttpRequest) errorHandler;
 
@@ -1121,18 +1148,24 @@ abstract class _EndpointConfig extends EndpointConfig {
 
   @override
   String get name;
+
+  /// Identifier for this endpoint, defaults to [name].
   @override
   String? get customKey;
 
   /// Whether the Mockzilla server should return an artificial error for a
-  /// request to this endpoint.
+  /// request to this endpoint. Defaults to [false].
   @override
   bool get shouldFail;
 
-  /// Optional, the artificial delay that Mockzilla should apply to responses
-  /// to simulate latency.
+  /// The artificial delay that Mockzilla should apply to responses
+  /// to simulate latency. Defaults to 100ms.
   @override
   Duration get delay;
+
+  /// Incrementing this will indicate a breaking change has been
+  /// made to this endpoint and will invalidate any cached data on the host
+  /// device without intervention by the user. Defaults to 1.
   @override
   int get versionCode;
 
@@ -1147,13 +1180,13 @@ abstract class _EndpointConfig extends EndpointConfig {
   DashboardOptionsConfig get dashboardOptionsConfig;
 
   /// This function is called when a network request is made to this endpoint,
-  /// note that if an error is being returned due to `failureProbability`
-  /// then `errorHandler` is used instead.
+  /// note that if an error is being returned due to [shouldFail] then
+  /// `errorHandler` is used instead.
   @override
   MockzillaHttpResponse Function(MockzillaHttpRequest) get defaultHandler;
 
   /// This function is called when, in response to a network request, the
-  /// server returns an error due to`failureProbability`.
+  /// server returns an error due to [shouldFail].
   @override
   MockzillaHttpResponse Function(MockzillaHttpRequest) get errorHandler;
 
@@ -1363,8 +1396,8 @@ mixin _$MockzillaConfig {
   /// Used for additional configuration when [isRelease] is [true].
   ReleaseModeConfig get releaseModeConfig => throw _privateConstructorUsedError;
 
-  /// Whether devices running Mockzilla are discoverable through the desktop
-  /// management UI.
+  /// Whether devices running Mockzilla are discoverable on the local network
+  /// through the desktop management app.
   bool get isNetworkDiscoveryEnabled => throw _privateConstructorUsedError;
 
   /// Create a copy of MockzillaConfig
@@ -1585,8 +1618,8 @@ class _$MockzillaConfigImpl implements _MockzillaConfig {
   @JsonKey()
   final ReleaseModeConfig releaseModeConfig;
 
-  /// Whether devices running Mockzilla are discoverable through the desktop
-  /// management UI.
+  /// Whether devices running Mockzilla are discoverable on the local network
+  /// through the desktop management app.
   @override
   @JsonKey()
   final bool isNetworkDiscoveryEnabled;
@@ -1674,8 +1707,8 @@ abstract class _MockzillaConfig implements MockzillaConfig {
   @override
   ReleaseModeConfig get releaseModeConfig;
 
-  /// Whether devices running Mockzilla are discoverable through the desktop
-  /// management UI.
+  /// Whether devices running Mockzilla are discoverable on the local network
+  /// through the desktop management app.
   @override
   bool get isNetworkDiscoveryEnabled;
 

--- a/docs/docs/additional_config.md
+++ b/docs/docs/additional_config.md
@@ -1,7 +1,10 @@
 
 # Additional Configuration
 
-Most Mockzilla configuration is relatively self-explanatory and documented [here](../dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/index.html).
+Most Mockzilla configuration is relatively self-explanatory with API references available at the following:
+
+* [Kotlin](../dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/index.html)
+* [Dart](https://pub.dev/documentation/mockzilla/latest/)
 
 ## Logging
 
@@ -20,6 +23,12 @@ By default, Mockzilla outputs minimal logging. If more is needed to help with de
         .setLogLevel(level: LogLevel.verbose)
         ...
         .build()
+    ```
+=== "Flutter"
+    ```dart
+    final mockzillaConfig = const MockzillaConfig(
+        logLevel: LogLevel.verbose,
+    );
     ```
 
 ## Release Mode

--- a/docs/docs/endpoints.md
+++ b/docs/docs/endpoints.md
@@ -79,7 +79,7 @@ Example:
     })
     ```
 === "Flutter"
-    It is recommended to use a JSON serialization library such as [freezed](https://pub.dev/packages/freezed) or [json_serializable](https://pub.dev/packages/json_serializable) that can generate `toJson()`/`fromJson()` method for you.
+    It is recommended to use a JSON serialization library such as [freezed](https://pub.dev/packages/freezed) or [json_serializable](https://pub.dev/packages/json_serializable) that can generate `toJson()`/`fromJson()` methods for you.
     ```dart
     MockzillaHttpResponse(
       body: jsonEncode(
@@ -223,4 +223,5 @@ Mockzilla supports artificially causing network requests to fail.
         shouldFail: true,
     )
     ```
-    **The default failure probability is 0**.
+
+**The default failure probability is 0**.

--- a/docs/docs/endpoints.md
+++ b/docs/docs/endpoints.md
@@ -184,8 +184,7 @@ either across all endpoints on the top level config, or on individual endpoints 
         defaultHandler: (request) => MockzillaHttpResponse(
         body: jsonEncode(const FetchDeparturesResponse(departures: []))),
         errorHandler: (request) => const MockzillaHttpResponse(statusCode: 418),
-        delayMean: 100,
-        delayVariance: 20,
+        delay: const Duration(milliseconds: 500),
     )
     ```
 
@@ -221,7 +220,7 @@ Mockzilla supports artificially causing network requests to fail.
         defaultHandler: (request) => MockzillaHttpResponse(
         body: jsonEncode(const FetchDeparturesResponse(departures: []))),
         errorHandler: (request) => const MockzillaHttpResponse(statusCode: 418),
-        failureProbability: 0
+        shouldFail: true,
     )
     ```
     **The default failure probability is 0**.

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,10 +1,11 @@
 # Overview
-A solution for running and configuring a local HTTP server to mimic REST API endpoints used by your iOS, Android or [KMM](https://kotlinlang.org/docs/multiplatform-mobile-getting-started.html) application.
+A solution for running and configuring a local HTTP server to mimic REST API endpoints used by your iOS, Android, [KMM](https://kotlinlang.org/docs/multiplatform-mobile-getting-started.html), or Flutter application.
 
 ## Supported Environments
 - Native iOS apps (written in Swift)
 - Native Android apps
-- Kotlin Multiplatform Apps (Android & iOS targets only).
+- Kotlin Multiplatform apps (Android & iOS targets only).
+- Flutter apps (Android & iOS targets only).
 
 ## Quick Start
 !!! important

--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -14,13 +14,4 @@
     Update the Mockzilla version to the latest Snapshot version found [here](https://s01.oss.sonatype.org/content/repositories/snapshots/com/apadmi/mockzilla/).
 
 === "Flutter"
-    If you wish to use the latest pre-release version of Mockzilla for Flutter, add the following dependency to your pubspec.yaml
-    file:
-
-    ```yaml
-    mockzilla:
-        git:
-            ref: develop
-            path: FlutterMockzilla/mockzilla
-            url: https://github.com/Apadmi-Engineering/Mockzilla
-    ```
+    Snapshots are published on [pub.dev](https://pub.dev/packages/mockzilla) as [pre-releases](https://dart.dev/tools/pub/publishing#publishing-prereleases).


### PR DESCRIPTION
- Updates documentation for Flutter v1.0, specifically...
  - Web documentation
  - Dart doc-strings
  - Repository READMEs with additional guidance for contributions

Merging this PR will close #210. Note this PR is targeting the `flutter-v1` branch.