### PR TITLE
chore: Add concurrency limitation to binary deployment

### DIFF
--- a/.github/workflows/action_deploy_binaries.yml
+++ b/.github/workflows/action_deploy_binaries.yml
@@ -10,6 +10,10 @@ on:
 env:
   is_snapshot: ${{ github.ref_type == 'branch' }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_type }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     environment: production


### PR DESCRIPTION
Stop the merging of multiple PRs in quick succession from triggering lots of builds