### PR TITLE
Fix Cocoapods version injection

### DIFF
--- a/build-logic/src/main/kotlin/com/apadmi/mockzilla/VersionUtils.kt
+++ b/build-logic/src/main/kotlin/com/apadmi/mockzilla/VersionUtils.kt
@@ -2,4 +2,5 @@ package com.apadmi.mockzilla
 
 import org.gradle.api.Project
 
-fun Project.injectedVersion() = properties["version"].toString().takeUnless { it.isBlank() || it == "unspecified" }
+fun Project.injectedVersion() = if (project.hasProperty("version")) properties["version"].toString()
+    .takeUnless { it.isBlank() || it == "unspecified" } else null


### PR DESCRIPTION
- Updates `Project.injectedVersion` to check if 'version' is defined before using it.