### PR TITLE
Update Cocoapods deployment fix

### DIFF
--- a/.github/workflows/action_deploy_binaries.yml
+++ b/.github/workflows/action_deploy_binaries.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - mockzilla-v**
 env:
-  is_snapshot: ${{ github.ref_type == 'branch' }}
+  is_snapshot: ${{ false }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_type }}
@@ -30,16 +30,16 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Install dependencies
         run: bundle install
-      - name: Deploy package to Maven Central
-        run: | 
-          echo "is_snapshot: $is_snapshot"
-          export GPG_TTY=$(tty)
-          bundle exec fastlane publish_to_maven is_snapshot:$is_snapshot
-        env:
-          GPG_PASSPHRASE:  ${{ secrets.GPG_PASSWORD }}
-          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      # - name: Deploy package to Maven Central
+      #   run: | 
+      #     echo "is_snapshot: $is_snapshot"
+      #     export GPG_TTY=$(tty)
+      #     bundle exec fastlane publish_to_maven is_snapshot:$is_snapshot
+      #   env:
+      #     GPG_PASSPHRASE:  ${{ secrets.GPG_PASSWORD }}
+      #     GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+      #     OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+      #     OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       - name: Deploy package to Github for SPM & Cocoapods
         run: bundle exec fastlane ios publish_swift_package is_snapshot:$is_snapshot
         env:

--- a/.github/workflows/action_deploy_binaries.yml
+++ b/.github/workflows/action_deploy_binaries.yml
@@ -8,7 +8,7 @@ on:
     tags:
       - mockzilla-v**
 env:
-  is_snapshot: ${{ false }}
+  is_snapshot: ${{ github.ref_type == 'branch' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_type }}
@@ -30,16 +30,16 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
       - name: Install dependencies
         run: bundle install
-      # - name: Deploy package to Maven Central
-      #   run: | 
-      #     echo "is_snapshot: $is_snapshot"
-      #     export GPG_TTY=$(tty)
-      #     bundle exec fastlane publish_to_maven is_snapshot:$is_snapshot
-      #   env:
-      #     GPG_PASSPHRASE:  ${{ secrets.GPG_PASSWORD }}
-      #     GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-      #     OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      #     OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+      - name: Deploy package to Maven Central
+        run: | 
+          echo "is_snapshot: $is_snapshot"
+          export GPG_TTY=$(tty)
+          bundle exec fastlane publish_to_maven is_snapshot:$is_snapshot
+        env:
+          GPG_PASSPHRASE:  ${{ secrets.GPG_PASSWORD }}
+          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
       - name: Deploy package to Github for SPM & Cocoapods
         run: bundle exec fastlane ios publish_swift_package is_snapshot:$is_snapshot
         env:

--- a/fastlane/fastfiles/lib.rb
+++ b/fastlane/fastfiles/lib.rb
@@ -32,7 +32,7 @@ platform :ios do
         sh("rm -rf apadmi-mockzilla-ios")
 
 
-        if options[:is_snapshot]
+        if !options[:is_snapshot]
             sh("git clone #{ENV["IOS_DEPLOY_URL"]} apadmi-mockzilla-ios")
         else
             sh("git clone -b deployment/snapshot #{ENV["IOS_DEPLOY_URL"]} apadmi-mockzilla-ios")

--- a/fastlane/fastfiles/lib.rb
+++ b/fastlane/fastfiles/lib.rb
@@ -42,9 +42,22 @@ platform :ios do
             cd apadmi-mockzilla-ios;
             rm -rf ./*;
             cp -r #{lane_context[:repo_root]}/SwiftMockzilla/ .;
+
+            git add .;
+            git add --force mockzilla.xcframework;
+            git add --force SwiftMockzilla.podspec;
+            git commit -m "Updating Package #{get_version_name(options)}";
+            git push;
         })
 
         if !options[:is_snapshot]
+            sh(%{
+                cd apadmi-mockzilla-ios;
+                git push
+                git tag v#{get_version_name(options)}
+                git push --tags
+            })
+
             # Push podspec to trunk
             sh(%{
                 cd apadmi-mockzilla-ios

--- a/fastlane/fastfiles/lib.rb
+++ b/fastlane/fastfiles/lib.rb
@@ -42,22 +42,9 @@ platform :ios do
             cd apadmi-mockzilla-ios;
             rm -rf ./*;
             cp -r #{lane_context[:repo_root]}/SwiftMockzilla/ .;
-
-            git add .;
-            git add --force mockzilla.xcframework;
-            git add --force SwiftMockzilla.podspec;
-            git commit -m "Updating Package #{get_version_name(options)}";
-            git push;
         })
 
         if !options[:is_snapshot]
-            sh(%{
-                cd apadmi-mockzilla-ios;
-                git push
-                git tag v#{get_version_name(options)}
-                git push --tags
-            })
-
             # Push podspec to trunk
             sh(%{
                 cd apadmi-mockzilla-ios

--- a/mockzilla/build.gradle.kts
+++ b/mockzilla/build.gradle.kts
@@ -45,7 +45,8 @@ kotlin {
             baseName = "mockzilla"
         }
         license = "{:type => 'MIT', :file => 'LICENSE'}"
-        source = "{ :git => 'https://github.com/Apadmi-Engineering/SwiftMockzilla.git', :tag => 'v$version' }"
+        // This is explicitly `getVersion()` and not `version`! The latter is shadowed in `cocoapods` scope.
+        source = "{ :git => 'https://github.com/Apadmi-Engineering/SwiftMockzilla.git', :tag => 'v${project.version}' }"
         extraSpecAttributes["vendored_frameworks"] = "'Mockzilla.xcframework'"
         extraSpecAttributes["source_files"] = "'Sources/SwiftMockzilla/SwiftMockzilla.swift'"
         extraSpecAttributes["swift_version"] = "'5.9.2'"


### PR DESCRIPTION
- Inverts check for snapshot builds on `publish_swift_package` lane.
  - Snapshot releases should operate on `deployment/snapshot` and _non-snapshots_ should operate on `main`.
- Updates fix for Cocoapods version injection by using non-shadowed `project.version` instead of `version`.