### PR TITLE
Expose checked errors to Swift

### DIFF
--- a/SwiftMockzilla/Sources/SwiftMockzilla/SwiftMockzilla.swift
+++ b/SwiftMockzilla/Sources/SwiftMockzilla/SwiftMockzilla.swift
@@ -14,7 +14,11 @@ public typealias ReleaseModeConfig = Mockzilla_commonMockzillaConfig.ReleaseMode
 public typealias MockzillaLogWriter = Mockzilla_commonMockzillaLogWriter
 
 public func startMockzilla(config mockzillaConfig: MockzillaConfig) -> MockzillaRuntimeParams {
-    MockzillaKt.startMockzilla(config: mockzillaConfig)
+    do {
+        return try MockzillaKt.startMockzilla(config: mockzillaConfig)
+    } catch {
+        fatalError("Failed to start Mockzilla server: \n\(error)")
+    }
 }
 
 public func stopMockzilla() {

--- a/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
+++ b/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
@@ -7,12 +7,15 @@ import com.apadmi.mockzilla.lib.internal.utils.FileIo
 import com.apadmi.mockzilla.lib.internal.utils.extractMetaData
 import com.apadmi.mockzilla.lib.models.MockzillaConfig
 import com.apadmi.mockzilla.lib.models.MockzillaRuntimeParams
+import com.apadmi.mockzilla.lib.models.PortConflictException
 
 /**
- * Starts the Mockzilla server,
+ * Internal method to start the Mockzilla server. Consumer apps should prefer using the top-level
+ * `startMockzilla()` function to avoid breaking changes.
  *
  * @param config The config with which to initialise mockzilla.
  */
+@Throws(PortConflictException::class)
 fun startMockzilla(config: MockzillaConfig): MockzillaRuntimeParams {
     config.validateInfoPlistOrThrow()
 


### PR DESCRIPTION
- Exposes `PortConflictException` to Swift when starting the Mockzilla server.
  - This is mostly for the benefit of the Flutter package to be able to detect an error has been thrown.
  - Errors are just handled in `SwiftMockzilla` by aborting with a message.