### PR TITLE
Attempt to fix grouped releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,15 +4,18 @@
   "packages": {
     "mockzilla": {
       "component": "mockzilla",
-      "extra-files": ["build.gradle.kts"]
+      "extra-files": ["build.gradle.kts"],
+      "pull-request-title-pattern": "chore(${branch?}): release Kmp libs libraries"
     },
     "mockzilla-common": {
       "component": "mockzilla-common",
-      "extra-files": ["build.gradle.kts"]
+      "extra-files": ["build.gradle.kts"],
+      "pull-request-title-pattern": "chore(${branch?}): release Kmp libs libraries"
     },
     "mockzilla-management": {
       "component": "mockzilla-management",
-      "extra-files": ["build.gradle.kts"]
+      "extra-files": ["build.gradle.kts"],
+      "pull-request-title-pattern": "chore(${branch?}): release Kmp libs libraries"
     },
     "FlutterMockzilla/mockzilla": {
       "component": "flutter_mockzilla",


### PR DESCRIPTION
The grouped KMP libs PR doesn't conform to the default `pull-request-title-pattern` when release-please attempts to locate the merged PRs when building a release. This is because of the linked versions.

This fix overrides the title pattern (using [this](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#pull-request-title)) to try and help release-please match the merged PR.