### PR TITLE
Attempt to fix grouped releases again

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,21 +1,19 @@
 {
+  "group-pull-request-title-pattern": "chore${scope}: release Kmp libs libraries",
   "release-type": "simple",
   "separate-pull-requests": true,
   "packages": {
     "mockzilla": {
       "component": "mockzilla",
-      "extra-files": ["build.gradle.kts"],
-      "pull-request-title-pattern": "chore(${branch?}): release Kmp libs libraries"
+      "extra-files": ["build.gradle.kts"]
     },
     "mockzilla-common": {
       "component": "mockzilla-common",
-      "extra-files": ["build.gradle.kts"],
-      "pull-request-title-pattern": "chore(${branch?}): release Kmp libs libraries"
+      "extra-files": ["build.gradle.kts"]
     },
     "mockzilla-management": {
       "component": "mockzilla-management",
-      "extra-files": ["build.gradle.kts"],
-      "pull-request-title-pattern": "chore(${branch?}): release Kmp libs libraries"
+      "extra-files": ["build.gradle.kts"]
     },
     "FlutterMockzilla/mockzilla": {
       "component": "flutter_mockzilla",


### PR DESCRIPTION
- Attempts applying the same work-around as is highlighted [here](https://github.com/googleapis/release-please/issues/2306).
  - Involves configuring the group PR name instead of the component name.
  - The [source](https://github.com/googleapis/release-please/blob/ace2bd5dc778f83c33ad5dee6807db5d0afdba36/src/strategies/base.ts#L579) of the GitHub action implies that the component title takes priority over the group title so the desktop & Flutter packages should be unaffected.