### PR TITLE
Add `workflow_dispatch` trigger to Flutter deployments

### DIFF
--- a/.github/workflows/action_deploy_flutter.yml
+++ b/.github/workflows/action_deploy_flutter.yml
@@ -1,6 +1,7 @@
 name: Publish to `mockzilla` pub.dev
 
 on:
+  workflow_dispatch:
   push:
     tags:
     - 'flutter_mockzilla-v[0-9]+.[0-9]+.[0-9]+*'

--- a/.github/workflows/action_deploy_flutter_android.yml
+++ b/.github/workflows/action_deploy_flutter_android.yml
@@ -1,6 +1,7 @@
 name: Publish to `mockzilla_android` pub.dev
 
 on:
+  workflow_dispatch:
   push:
     tags:
     - 'flutter_mockzilla_android-v[0-9]+.[0-9]+.[0-9]+*'

--- a/.github/workflows/action_deploy_flutter_ios.yml
+++ b/.github/workflows/action_deploy_flutter_ios.yml
@@ -1,6 +1,7 @@
 name: Publish to `mockzilla_ios` pub.dev
 
 on:
+  workflow_dispatch:
   push:
     tags:
     - 'flutter_mockzilla_ios-v[0-9]+.[0-9]+.[0-9]+*'

--- a/.github/workflows/action_deploy_flutter_platform_interface.yml
+++ b/.github/workflows/action_deploy_flutter_platform_interface.yml
@@ -1,6 +1,7 @@
 name: Publish `mockzilla_platform_interface` to pub.dev
 
 on:
+  workflow_dispatch:
   push:
     tags:
     - 'flutter_mockzilla_platform_interface-v[0-9]+.[0-9]+.[0-9]+*'


### PR DESCRIPTION
- Adds `workflow_dispatch` trigger to Flutter deployment workflows, allowing them to be started manually.
- The tag trigger will likely also need updating as I _think_ release-please uses the component name in the tag template (need to confirm).