### PR TITLE
fix: Update Kermit to v2.0.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ agp = "8.7.3" # https://developer.android.com/build/releases/gradle-plugin
 ksp = "2.1.0-1.0.29" # https://github.com/google/ksp
 
 # Logging
-kermit = "1.2.2" # https://github.com/touchlab/Kermit
+kermit = "2.0.5" # https://github.com/touchlab/Kermit
 
 # Config
 buildKonfig = "0.15.2" # https://github.com/yshrsmz/BuildKonfig

--- a/mockzilla-management-ui/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.kt
+++ b/mockzilla-management-ui/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.kt
@@ -51,7 +51,7 @@ actual class ZeroConfSdkWrapper actual constructor(
         }.forEach { (hostAddress, jmDns) ->
             jmDns.removeServiceListener(serviceType, this@ZeroConfSdkWrapper)
             jmDnsInstances.remove(hostAddress)
-            Logger.d(tag = tag) { "Removing stale listener for $hostAddress" }
+            Logger.d(tag) { "Removing stale listener for $hostAddress" }
         }
 
         // Add new listeners
@@ -63,7 +63,8 @@ actual class ZeroConfSdkWrapper actual constructor(
             jmDns.registerServiceType(serviceType)
             jmDns.addServiceListener(serviceType, this@ZeroConfSdkWrapper)
             jmDnsInstances[inetAddress.hostAddress] = jmDns
-            Logger.i(tag = tag) { "Listening on ${inetAddress.hostAddress}" }
+
+            Logger.i(tag) { "Listening on ${inetAddress.hostAddress}" }
         }
     }
 

--- a/mockzilla/src/jvmMain/kotlin/com/apadmi/mockzilla/lib/JvmMockzilla.kt
+++ b/mockzilla/src/jvmMain/kotlin/com/apadmi/mockzilla/lib/JvmMockzilla.kt
@@ -39,7 +39,7 @@ fun startMockzilla(
 ) {
     object : ZeroConfDiscoveryService {
         override suspend fun makeDiscoverable(metaData: MetaData, port: Int) {
-            Logger.i(tag = "Mockzilla") { "ZeroConf not supported for JVM Mockzilla" }
+            Logger.i("Mockzilla") { "ZeroConf not supported for JVM Mockzilla" }
         }
     }
 }


### PR DESCRIPTION
Updates Kermit and removes named argument for tag to sidestep conflicting overloads