### PR TITLE
Update Flutter package inter-dependencies

### DIFF
--- a/FlutterMockzilla/mockzilla/example/ios/Podfile.lock
+++ b/FlutterMockzilla/mockzilla/example/ios/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - mockzilla_ios (0.0.1):
     - Flutter
-    - SwiftMockzilla (= 2.1.2)
-  - SwiftMockzilla (2.1.2)
+    - SwiftMockzilla (= 2.1.3)
+  - SwiftMockzilla (2.1.3)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  mockzilla_ios: d283ee5106c7de0b82e35563f16eef7dc050153f
-  SwiftMockzilla: 20cb652bd44c7e0f4ee460cd2ec000a58a49f2e4
+  mockzilla_ios: e05414bb2bca4b44bdbbd1ab420d9cc1a0634f0f
+  SwiftMockzilla: 7e6b62a09bea9ea6d7287db510cc05eb538f6216
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 

--- a/FlutterMockzilla/mockzilla/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla/pubspec.yaml
@@ -20,9 +20,9 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  mockzilla_platform_interface: ^1.0.0
-  mockzilla_android: ^1.0.0
-  mockzilla_ios: ^1.0.0
+  mockzilla_platform_interface: ^1.1.0
+  mockzilla_android: ^1.1.0
+  mockzilla_ios: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla_android/android/build.gradle
+++ b/FlutterMockzilla/mockzilla_android/android/build.gradle
@@ -51,7 +51,7 @@ android {
     }
 
     dependencies {
-        implementation "com.apadmi:mockzilla:2.1.2"
+        implementation "com.apadmi:mockzilla:2.1.3"
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.8.0'
     }

--- a/FlutterMockzilla/mockzilla_android/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_android/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.15.0
-  mockzilla_platform_interface: ^1.0.0
+  mockzilla_platform_interface: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/FlutterMockzilla/mockzilla_ios/example/ios/Podfile.lock
+++ b/FlutterMockzilla/mockzilla_ios/example/ios/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - Flutter (1.0.0)
   - mockzilla_ios (0.0.1):
     - Flutter
-    - SwiftMockzilla (= 2.1.2)
-  - SwiftMockzilla (2.1.2)
+    - SwiftMockzilla (= 2.1.3)
+  - SwiftMockzilla (2.1.3)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -21,8 +21,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  mockzilla_ios: d283ee5106c7de0b82e35563f16eef7dc050153f
-  SwiftMockzilla: 20cb652bd44c7e0f4ee460cd2ec000a58a49f2e4
+  mockzilla_ios: e05414bb2bca4b44bdbbd1ab420d9cc1a0634f0f
+  SwiftMockzilla: 7e6b62a09bea9ea6d7287db510cc05eb538f6216
 
 PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
 

--- a/FlutterMockzilla/mockzilla_ios/ios/mockzilla_ios.podspec
+++ b/FlutterMockzilla/mockzilla_ios/ios/mockzilla_ios.podspec
@@ -21,5 +21,5 @@ The iOS implementation for the mockzilla plugin.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
 
-  s.dependency 'SwiftMockzilla', '2.1.2'
+  s.dependency 'SwiftMockzilla', '2.1.3'
 end

--- a/FlutterMockzilla/mockzilla_ios/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ios/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.15.0
-  mockzilla_platform_interface: ^1.0.0
+  mockzilla_platform_interface: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Updates Kotlin/Swift Mockzilla dependencies from `2.1.2` -> `2.1.3`.
- Updates Flutter package constraints to require `1.1.0` as the new minimum
  - Consumers of Mockzilla on iOS may be required to run `pod update SwiftMockzilla` when updating.

**Note:** Flutter package versions are updated by release-please in the associated release-PRs.