### PR TITLE
Ignore symlink in Flutter iOS package

### DIFF
--- a/FlutterMockzilla/mockzilla_ios/example/.gitignore
+++ b/FlutterMockzilla/mockzilla_ios/example/.gitignore
@@ -43,3 +43,6 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Generated symlinks
+ios/.symlinks/


### PR DESCRIPTION
- Fixes the package validation issue raised when attempting to publish `mockzilla_ios` 1.1.0.