### PR TITLE
Fix iOS 16.X crash

### DIFF
--- a/FlutterMockzilla/mockzilla_ios/ios/mockzilla_ios/Sources/mockzilla_ios/ProxyMockzillaLogger.swift
+++ b/FlutterMockzilla/mockzilla_ios/ios/mockzilla_ios/Sources/mockzilla_ios/ProxyMockzillaLogger.swift
@@ -15,9 +15,9 @@ class ProxyMockzillaLogger: MockzillaLogWriter {
     }
     
     func log(logLevel: MockzillaLogLevel, message: String, tag: String, throwable: KotlinThrowable?) {
-        do {
-            try DispatchQueue.main.asyncAndWait {
-                try flutterApi.log(
+        DispatchQueue.main.async {
+            do {
+                try self.flutterApi.log(
                     logLevel: BridgeLogLevel.fromNative(logLevel),
                     message: message as String,
                     tag: tag as String,
@@ -26,9 +26,9 @@ class ProxyMockzillaLogger: MockzillaLogWriter {
                         // Intentionally blank.
                     }
                 )
+            } catch {
+                // Intentionally blank as this is a fire and forget call
             }
-        } catch {
-            // Intentionally blank as this is a fire and forget call.
         }
     }
 }


### PR DESCRIPTION
- Fixes the crash caused on iOS 16 and lower that looks to have been caused by a deadlock issue down to the use of `asyncAndWait`. (fixes #389)