### PR TITLE
fix: make use of port re-binding

### DIFF
--- a/mockzilla-common/src/commonMain/kotlin/com/apadmi/mockzilla/lib/models/Exceptions.kt
+++ b/mockzilla-common/src/commonMain/kotlin/com/apadmi/mockzilla/lib/models/Exceptions.kt
@@ -8,8 +8,9 @@ package com.apadmi.mockzilla.lib.models
  * `MockzillaConfig`.
  *
  * @property port The number of the port that was used to start the Mockzilla server.
+ * @property cause
  */
-class PortConflictException(val port: Int) : RuntimeException() {
+class PortConflictException(val port: Int, override val cause: Throwable?) : RuntimeException() {
     override val message: String
         get() = "Attempted to start Mockzilla server on a port that is already occupied by another process ($port)."
 }

--- a/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/AndroidErrorUtils.kt
+++ b/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/AndroidErrorUtils.kt
@@ -1,0 +1,5 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.apadmi.mockzilla.lib.internal.utils
+
+actual typealias AddressAlreadyInUseException = java.net.BindException

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.kt
@@ -5,7 +5,9 @@ import com.apadmi.mockzilla.lib.internal.di.DependencyInjector
 import com.apadmi.mockzilla.lib.internal.plugin.SimpleAuthPlugin
 import com.apadmi.mockzilla.lib.internal.service.AuthenticationConstants
 import com.apadmi.mockzilla.lib.internal.service.TokensService
+import com.apadmi.mockzilla.lib.internal.utils.AddressAlreadyInUseException
 import com.apadmi.mockzilla.lib.internal.utils.JsonProvider
+import com.apadmi.mockzilla.lib.internal.utils.isSomeMatchInChain
 import com.apadmi.mockzilla.lib.models.MockzillaConfig
 import com.apadmi.mockzilla.lib.models.MockzillaRuntimeParams
 import com.apadmi.mockzilla.lib.models.PortConflictException
@@ -53,9 +55,21 @@ private fun Application.setupServerEnvironment(job: CompletableJob, di: Dependen
     configureEndpoints(job, di)
 }
 
+private fun EmbeddedServer<*, *>.startWithErrorHandling(di: DependencyInjector) = try {
+    start(wait = false)
+} catch (e: Exception) {
+    if (e.isSomeMatchInChain { it is AddressAlreadyInUseException }) {
+        PortConflictException(di.config.port, e).also { exception ->
+            di.logger.e(exception.message, exception)
+            throw exception
+        }
+    } else {
+        throw e
+    }
+}
+
 internal fun startServer(port: Int, di: DependencyInjector) = runBlocking {
     stopServer()
-    assertPortAvailability(port, di)
 
     val job = SupervisorJob().also { job = it }
     val serverEngine = embeddedServer(CIO, configure = {
@@ -72,7 +86,7 @@ internal fun startServer(port: Int, di: DependencyInjector) = runBlocking {
     }).apply {
         application.setupServerEnvironment(job = job, di = di)
         server = this.application.engine
-        start(wait = false)
+        startWithErrorHandling(di)
     }
 
     val actualPort = serverEngine.application.engine.resolvedConnectors()
@@ -95,15 +109,6 @@ internal fun startServer(port: Int, di: DependencyInjector) = runBlocking {
 internal fun stopServer() = runBlocking {
     job?.cancel()
     server?.stop()
-}
-
-internal suspend fun assertPortAvailability(port: Int, di: DependencyInjector) {
-    if (!di.socketIo.isPortAvailable(port)) {
-        PortConflictException(port).also { exception ->
-            di.logger.e(exception.message, exception)
-            throw exception
-        }
-    }
 }
 
 private fun startNetworkDiscoveryBroadcastIfNeeded(

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ErrorUtils.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ErrorUtils.kt
@@ -1,0 +1,16 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.apadmi.mockzilla.lib.internal.utils
+
+expect class AddressAlreadyInUseException
+
+fun Throwable.isSomeMatchInChain(predicate: (Throwable) -> Boolean): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (predicate(current)) {
+            return true
+        }
+        current = current.cause
+    }
+    return false
+}

--- a/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ErrorUtils.kt
+++ b/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ErrorUtils.kt
@@ -1,0 +1,7 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.apadmi.mockzilla.lib.internal.utils
+
+import io.ktor.utils.io.errors.PosixException.AddressAlreadyInUseException as KtorAddressAlreadyInUseException
+
+actual typealias AddressAlreadyInUseException = KtorAddressAlreadyInUseException

--- a/mockzilla/src/jvmMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ErrotUtils.kt
+++ b/mockzilla/src/jvmMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/ErrotUtils.kt
@@ -1,0 +1,5 @@
+@file:Suppress("FILE_NAME_MATCH_CLASS")
+
+package com.apadmi.mockzilla.lib.internal.utils
+
+actual typealias AddressAlreadyInUseException = java.net.BindException


### PR DESCRIPTION
Previous implementation doesn't make use of ktors `reuseAddress` functionality since it manually checks if the port is in use. Often in these cases (if it was this process using the port) ktor can rebind the same port with no issues.

The new approach relies on letting Ktor tell us when it can't do this and handling the exception at that point instead of proactively throwing it.