### PR TITLE
Feature/component previews

### DIFF
--- a/mockzilla-management-ui/build.gradle.kts
+++ b/mockzilla-management-ui/build.gradle.kts
@@ -24,6 +24,7 @@ kotlin {
             implementation(compose.preview)
             implementation(compose.components.resources)
             implementation(compose.materialIconsExtended)
+            implementation(compose.components.uiToolingPreview)
 
             /* Localisable Strings */
             implementation(libs.lyricist.library)
@@ -140,6 +141,7 @@ dependencies {
     macAmd64(compose.desktop.macos_x64)
     macAarch64(compose.desktop.macos_arm64)
     windowsAmd64(compose.desktop.windows_x64)
+    debugImplementation(compose.uiTooling)
 }
 
 configurations.all {

--- a/mockzilla-management-ui/build.gradle.kts
+++ b/mockzilla-management-ui/build.gradle.kts
@@ -141,6 +141,8 @@ dependencies {
     macAmd64(compose.desktop.macos_x64)
     macAarch64(compose.desktop.macos_arm64)
     windowsAmd64(compose.desktop.windows_x64)
+
+    /* Compose previews */
     debugImplementation(compose.uiTooling)
 }
 

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/components/EmptyState.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/components/EmptyState.kt
@@ -1,10 +1,12 @@
 package com.apadmi.mockzilla.desktop.ui.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -12,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun EmptyState(
@@ -33,6 +36,17 @@ fun EmptyState(
             text = description,
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Preview
+@Composable
+fun EmptyStatePreview() = PreviewSurface {
+    Box(modifier = Modifier.size(200.dp)) {
+        EmptyState(
+            title = "Title",
+            description = "Description text\non multiple lines",
         )
     }
 }

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/components/ErrorBanner.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/components/ErrorBanner.kt
@@ -36,6 +36,7 @@ import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
 import com.apadmi.mockzilla.desktop.ui.AppRootViewModel.State.*
 import com.apadmi.mockzilla.desktop.ui.theme.theme_warning_background
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 private fun Connected.ErrorBannerState.bannerText(strings: Strings): String =
     when (this) {
@@ -78,6 +79,26 @@ fun AnimatedErrorBanner(
     errorBannerState?.let {
         ErrorBanner(errorBannerState, onRefreshAll = onRefreshAll, onDismissError = onDismissError)
     }
+}
+
+@Preview
+@Composable
+fun ConnectionLostPreview() = PreviewSurface {
+    ErrorBanner(
+        state = Connected.ErrorBannerState.ConnectionLost,
+        onRefreshAll = {},
+        onDismissError = {},
+    )
+}
+
+@Preview
+@Composable
+fun UnknownErrorPreview() = PreviewSurface {
+    ErrorBanner(
+        state = Connected.ErrorBannerState.UnknownError,
+        onRefreshAll = {},
+        onDismissError = {},
+    )
 }
 
 @Composable

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/components/PreviewSurface.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/components/PreviewSurface.kt
@@ -1,14 +1,16 @@
 package com.apadmi.mockzilla.desktop.ui.components
 
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
 import com.apadmi.mockzilla.desktop.ui.theme.AppTheme
+import com.apadmi.mockzilla.desktop.ui.theme.LocalForceDarkMode
 
 @Composable
 fun PreviewSurface(
-    color: Color = Color.DarkGray,
+    darkTheme: Boolean = LocalForceDarkMode.current || isSystemInDarkTheme(),
     content: @Composable () -> Unit
-) = AppTheme {
-    Surface(color = color, content = content)
+) = AppTheme(useDarkTheme = darkTheme) {
+    Surface(color = MaterialTheme.colorScheme.surface, content = content)
 }

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
@@ -26,6 +26,7 @@ import com.apadmi.mockzilla.desktop.di.utils.getViewModel
 import com.apadmi.mockzilla.desktop.engine.connection.DetectedDevice
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 import com.apadmi.mockzilla.desktop.ui.components.StandardTextTooltip
 import com.apadmi.mockzilla.desktop.ui.theme.alternatingBackground
 import com.apadmi.mockzilla.desktop.ui.widgets.deviceconnection.DeviceConnectionViewModel.State
@@ -34,6 +35,7 @@ import com.apadmi.mockzilla.desktop.utils.Platform
 import com.apadmi.mockzilla_management_ui.generated.resources.Res
 import com.apadmi.mockzilla_management_ui.generated.resources.mockzilla_logo
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 private fun DetectedDevice.State.toolTipText(strings: Strings) = when (this) {
     DetectedDevice.State.NotYourSimulator -> strings.widgets.deviceConnection.tooltips.notYourSimulator
@@ -109,6 +111,32 @@ fun DeviceConnectionContent(
                 )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+fun DeviceConnectionContentPreview() = PreviewSurface {
+    Box(modifier = Modifier.padding(horizontal = 16.dp)) {
+        DeviceConnectionContent(
+            state = State(
+                ipAndPort = "127.0.0.1:60000",
+                connectionState = State.ConnectionState.Connecting,
+                devices = listOf(
+                    DetectedDevice(
+                        connectionName = "iPhone",
+                        metaData = null,
+                        hostAddress = "127.0.0.1",
+                        hostAddresses = listOf(),
+                        port = 60000,
+                        adbConnection = null,
+                        state = DetectedDevice.State.ReadyToConnect,
+                    )
+                ),
+            ),
+            onIpAndPortChanged = {},
+            onTapDevice = {},
+        )
     }
 }
 

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/deviceconnection/DeviceConnectionWidget.kt
@@ -137,7 +137,7 @@ private fun DevicesList(
 
     itemsIndexed(devices, key = { _, device -> device.connectionName }) { index, device ->
         Row(
-            modifier = Modifier.animateItemPlacement().alternatingBackground(index).fillMaxWidth()
+            modifier = Modifier.animateItem().alternatingBackground(index).fillMaxWidth()
                 .padding(start = 16.dp, end = 8.dp, top = 8.dp, bottom = 8.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/devicetabs/DeviceTabsWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/devicetabs/DeviceTabsWidget.kt
@@ -16,12 +16,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.apadmi.mockzilla.desktop.di.utils.getViewModel
+import com.apadmi.mockzilla.desktop.engine.device.Device
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 import com.apadmi.mockzilla.desktop.ui.scaffold.HorizontalTab
 import com.apadmi.mockzilla.desktop.ui.scaffold.HorizontalTabList
 import com.apadmi.mockzilla.desktop.ui.utils.desktopTertiaryPointerClick
 import com.apadmi.mockzilla.desktop.ui.widgets.devicetabs.DeviceTabsViewModel.State
+import org.jetbrains.compose.ui.tooling.preview.Preview
 
 @Composable
 fun DeviceTabsWidget(
@@ -105,4 +108,30 @@ fun DeviceTabsWidgetContent(
             },
         )
     }
+}
+
+@Preview
+@Composable
+fun DeviceTabsWidgetContentPreview() = PreviewSurface {
+    DeviceTabsWidgetContent(
+        state = State(
+            devices = listOf(
+                State.DeviceTabEntry(
+                    name = "Android",
+                    isActive = true,
+                    isConnected = true,
+                    underlyingDevice = Device(ip = "127.0.0.1", port = "8080"),
+                ),
+                State.DeviceTabEntry(
+                    name = "iOS",
+                    isActive = false,
+                    isConnected = false,
+                    underlyingDevice = Device(ip = "127.0.0.1", port = "8080"),
+                )
+            )
+        ),
+        onSelect = {},
+        onAddNewDevice = {},
+        onCloseTab = {},
+    )
 }

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/details/EndpointDetailsWidget.kt
@@ -57,14 +57,17 @@ import com.apadmi.mockzilla.desktop.engine.device.Device
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
 import com.apadmi.mockzilla.desktop.ui.components.EmptyState
-
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 import com.apadmi.mockzilla.desktop.ui.scaffold.HorizontalTab
 import com.apadmi.mockzilla.desktop.ui.scaffold.HorizontalTabList
 import com.apadmi.mockzilla.desktop.ui.theme.alternatingBackground
+import com.apadmi.mockzilla.lib.internal.models.SerializableEndpointConfig
+import com.apadmi.mockzilla.lib.models.DashboardOptionsConfig
 import com.apadmi.mockzilla.lib.models.DashboardOverridePreset
 import com.apadmi.mockzilla.lib.models.EndpointConfiguration
 
 import io.ktor.http.HttpStatusCode
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 import kotlinx.coroutines.launch
@@ -213,6 +216,47 @@ fun EndpointDetailsWidgetContent(
             }
         }
     }
+}
+
+@Preview
+@Composable
+fun EndpointDetailsWidgetContentPreview() = PreviewSurface {
+    EndpointDetailsWidgetContent(
+        state = EndpointDetailsViewModel.State.Endpoint(
+            config = SerializableEndpointConfig.allNulls(
+                key = EndpointConfiguration.Key("Foo"),
+                name = "Foobar",
+                versionCode = 1,
+            ),
+            defaultBody = null,
+            defaultStatus = null,
+            defaultHeaders = null,
+            errorBody = null,
+            errorStatus = null,
+            errorHeaders = null,
+            fail = null,
+            delayMillis = null,
+            jsonEditingDefault = false,
+            jsonEditingError = false,
+            presets = DashboardOptionsConfig(
+                errorPresets = listOf(),
+                successPresets = listOf(),
+            )
+        ),
+        onDefaultBodyChange = {},
+        onErrorBodyChange = {},
+        onFailChange = {},
+        onJsonDefaultEditingChange = {},
+        onJsonErrorEditingChange = {},
+        onDefaultStatusCodeChange = {},
+        onErrorStatusCodeChange = {},
+        onDelayChange = {},
+        onDefaultHeadersChange = {},
+        onErrorHeadersChange = {},
+        onDefaultPresetSelected = {},
+        onErrorPresetSelected = {},
+        onResetAll = {},
+    )
 }
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -30,10 +30,12 @@ import com.apadmi.mockzilla.desktop.di.utils.getViewModel
 import com.apadmi.mockzilla.desktop.engine.device.Device
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 import com.apadmi.mockzilla.desktop.ui.components.StandardTextTooltip
 import com.apadmi.mockzilla.desktop.ui.theme.alternatingBackground
 import com.apadmi.mockzilla.desktop.ui.widgets.endpoints.endpoints.EndpointsViewModel.*
 import com.apadmi.mockzilla.lib.models.EndpointConfiguration.*
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 @Composable
@@ -78,6 +80,55 @@ fun EndpointsWidgetContent(
             onFilterUpdate
         )
     }
+}
+
+@Preview
+@Composable
+fun EndpointsWidgetContentPreview() = PreviewSurface {
+    EndpointsWidgetContent(
+        state = State.EndpointsList(
+            endpoints = listOf(
+                State.EndpointConfig(
+                    key = Key("1"),
+                    name = "FooBar",
+                    fail = false,
+                    isCheckboxTicked = false,
+                    hasValuesOverridden = false,
+                    display = true,
+                ),
+                State.EndpointConfig(
+                    key = Key("2"),
+                    name = "Foo",
+                    fail = true,
+                    isCheckboxTicked = true,
+                    hasValuesOverridden = false,
+                    display = true,
+                ),
+                State.EndpointConfig(
+                    key = Key("3"),
+                    name = "FooBuzz",
+                    fail = false,
+                    isCheckboxTicked = false,
+                    hasValuesOverridden = true,
+                    display = true,
+                ),
+                State.EndpointConfig(
+                    key = Key("4"),
+                    name = "Foobar",
+                    fail = false,
+                    isCheckboxTicked = false,
+                    hasValuesOverridden = false,
+                    display = true,
+                ),
+            ),
+            filter = "Foo",
+        ),
+        onAllCheckboxChanged = {},
+        onCheckboxChanged = { _, _ -> },
+        onFailChanged = { _, _ -> },
+        onFilterUpdate = {},
+        onEndpointClicked = {},
+    )
 }
 
 @Composable

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/metadata/MetaDataWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/metadata/MetaDataWidget.kt
@@ -25,6 +25,7 @@ import com.apadmi.mockzilla.desktop.di.utils.getViewModel
 import com.apadmi.mockzilla.desktop.engine.device.Device
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 
 import com.apadmi.mockzilla.desktop.ui.widgets.metadata.MetaDataWidgetViewModel.*
 import com.apadmi.mockzilla.lib.models.MetaData
@@ -33,7 +34,9 @@ import com.apadmi.mockzilla_management_ui.generated.resources.Res
 import com.apadmi.mockzilla_management_ui.generated.resources.mockzilla_logo
 
 import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
+import kotlin.String
 
 private fun RunTarget.label(strings: Strings) = when (this) {
     RunTarget.AndroidDevice,
@@ -120,4 +123,19 @@ fun MetaDataRow(
                 .align(Alignment.BottomCenter)
         )
     }
+}
+
+@Preview
+@Composable
+fun MetaDataListViewPreview() = PreviewSurface {
+    MetaDataListView(
+        metaData = MetaData(
+            appName = "App name",
+            appPackage = "app.package",
+            operatingSystemVersion = "OS",
+            deviceModel = "Model",
+            appVersion = "App version",
+            mockzillaVersion = "Mockzilla version"
+        )
+    )
 }

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/misccontrols/MiscControlsWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/misccontrols/MiscControlsWidget.kt
@@ -8,6 +8,8 @@ import com.apadmi.mockzilla.desktop.di.utils.getViewModel
 import com.apadmi.mockzilla.desktop.engine.device.Device
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 @Composable
@@ -33,4 +35,13 @@ fun MiscControlsWidgetContent(
     Button(onClick = onClearAllOverrides) {
         Text(strings.widgets.miscControls.clearOverrides)
     }
+}
+
+@Preview
+@Composable
+fun MiscControlsWidgetContentPreview() = PreviewSurface {
+    MiscControlsWidgetContent(
+        onRefreshAll = {},
+        onClearAllOverrides = {},
+    )
 }

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/monitorlogs/MonitorLogsWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/monitorlogs/MonitorLogsWidget.kt
@@ -32,6 +32,7 @@ import com.apadmi.mockzilla.desktop.di.utils.getViewModel
 import com.apadmi.mockzilla.desktop.engine.device.Device
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 import com.apadmi.mockzilla.desktop.ui.theme.alternatingBackground
 import com.apadmi.mockzilla.desktop.ui.theme.httpStatusCode_1xx
 import com.apadmi.mockzilla.desktop.ui.theme.httpStatusCode_2xx
@@ -41,6 +42,7 @@ import com.apadmi.mockzilla.desktop.ui.theme.httpStatusCode_5xx
 import com.apadmi.mockzilla.lib.internal.models.LogEvent
 
 import io.ktor.http.HttpStatusCode
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
 @Suppress("MAGIC_NUMBER")
@@ -103,6 +105,31 @@ fun LogRow(modifier: Modifier, event: LogEvent) =
             onDraw = { drawCircle(color = event.status.color()) })
         Text("${event.status.description} ${event.method}: ${event.url}")
     }
+
+@Preview
+@Composable
+fun MonitorLogsWidgetContentPreview() = PreviewSurface {
+    MonitorLogsWidgetContent(
+        state = MonitorLogsViewModel.State.DisplayLogs(
+            entries = sequenceOf(
+                LogEvent(
+                    timestamp = 1000,
+                    url = "https://www.example.com/url",
+                    requestBody = "request body",
+                    requestHeaders = mapOf(),
+                    responseHeaders = mapOf(),
+                    responseBody = "response body",
+                    status = HttpStatusCode.OK,
+                    delay = 50,
+                    method = "GET",
+                    isIntendedFailure = false,
+                )
+            ),
+        ),
+        onClearAll = {},
+        onViewDetail = { _ -> },
+    )
+}
 
 @Composable
 private fun MonitorLogsList(

--- a/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -29,7 +31,10 @@ import com.apadmi.mockzilla.desktop.di.utils.getViewModel
 import com.apadmi.mockzilla.desktop.i18n.LocalStrings
 import com.apadmi.mockzilla.desktop.i18n.Strings
 import com.apadmi.mockzilla.desktop.ui.components.EmptyState
+import com.apadmi.mockzilla.desktop.ui.components.PreviewSurface
 import com.apadmi.mockzilla.lib.internal.models.LogEvent
+import io.ktor.http.HttpStatusCode
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -184,6 +189,43 @@ fun MonitorLogDetailsEmptyContent(
         title = strings.widgets.logDetails.emptyTitle,
         description = strings.widgets.logDetails.emptyDescription
     )
+}
+
+@Preview
+@Composable
+fun LogDetailsContentPreview() = PreviewSurface {
+    LogDetailsContent(
+        logDetail = LogEvent(
+            timestamp = 1000,
+            url = "https://www.example.com/url",
+            requestBody = "request body",
+            requestHeaders = mapOf(),
+            responseHeaders = mapOf(),
+            responseBody = "response body",
+            status = HttpStatusCode.OK,
+            delay = 50,
+            method = "GET",
+            isIntendedFailure = false,
+        ),
+        visible = MonitorLogDetailsViewModel.State.ViewDetails(
+            requestHeaders = true,
+            requestBody = true,
+            responseHeaders = true,
+            responseBody = true,
+        ),
+        onViewRequestHeaders = {},
+        onViewRequestBody = {},
+        onViewResponseHeaders = {},
+        onViewResponseBody = {},
+    )
+}
+
+@Preview
+@Composable
+fun MonitorLogDetailsEmptyContentPreview() = PreviewSurface {
+    Box(modifier = Modifier.size(300.dp)) {
+        MonitorLogDetailsEmptyContent()
+    }
 }
 
 @Composable


### PR DESCRIPTION
IDE support has improved a lot since when this project started, and we can now get previews of components displayed in the IDE like for native Android development. I tried to use a PreviewParameter so every preview could create 2 in the IDE for light+dark mode but it seems like support for that isn't quite there yet as I was only able to see the first of the preview parameters.