### PR TITLE
feat: move docs to cloud pages

### DIFF
--- a/.github/workflows/action_deploy_docs.yml
+++ b/.github/workflows/action_deploy_docs.yml
@@ -31,24 +31,32 @@ jobs:
         with:
           distribution: 'temurin' # See 'Supported distributions' for available options
           java-version: '17'
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
       - run: pip install -r docs/requirements.txt
       - run: bundle install
       - run: bundle exec fastlane generate_docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
+          name: generated_docs
           path: './generated_docs'
 
   # Deployment job
   deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    environment: production-docs
     runs-on: macos-latest
     needs: build
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - uses: actions/download-artifact@v5
+        name: generated_docs
+      - name: Debug
+        run: |
+          mkdir generated_docs
+          ls -l
+          tar -xf artifact.tar -C generated_docs
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy generated_docs --project-name=mockzilla-docs
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/FlutterMockzilla/mockzilla/README.md
+++ b/FlutterMockzilla/mockzilla/README.md
@@ -8,7 +8,7 @@ A Flutter plugin for running and configuring a local, mock HTTP server that allo
 |-------------|-------------------------|-------|
 | **Support** | SDK 21+ (Target SDK 36) | 13.0+ |
 
-**Full documentation available [here!](https://apadmi-engineering.github.io/Mockzilla/)**
+**Full documentation available [here!](https://mockzilla.apadmi.dev/)**
 
 ## Why use Mockzilla?
 
@@ -22,7 +22,7 @@ A Flutter plugin for running and configuring a local, mock HTTP server that allo
 
 ## To hit the ground running
 
-> ⚠️ **Warning:** Mockzilla is a development tool only. Do not use it in production! Advice on how to do this using different Dart entrypoints can be found [here](https://apadmi-engineering.github.io/Mockzilla/#recommendation).
+> ⚠️ **Warning:** Mockzilla is a development tool only. Do not use it in production! Advice on how to do this using different Dart entrypoints can be found [here](https://mockzilla.apadmi.dev/#recommendation).
 
 **(1)** Create your Mockzilla server config and add mocked endpoints.
 
@@ -56,6 +56,6 @@ The Mockzilla Desktop application lets you inspect and configure the mocked endp
 
 <img src="https://raw.githubusercontent.com/Apadmi-Engineering/Mockzilla/refs/heads/develop/docs/docs/desktop/img/desktop_demo.gif">
 
-More information about Mockzilla Desktop can be found [here](https://apadmi-engineering.github.io/Mockzilla/desktop/overview/).
+More information about Mockzilla Desktop can be found [here](https://mockzilla.apadmi.dev/desktop/overview/).
 
 > ℹ️ **Note:** Mockzilla Desktop replaces the web console from version 1.0.0 onwards. The web console is now deprecated and will eventually be retired.

--- a/FlutterMockzilla/mockzilla/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla/pubspec.yaml
@@ -3,10 +3,10 @@ description: A solution for configuring and running a local HTTP server as part 
 # x-release-please-start-version
 version: 1.3.0
 # x-release-please-end
-homepage: https://apadmi-engineering.github.io/Mockzilla/
+homepage: https://mockzilla.apadmi.dev/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues
-documentation: https://apadmi-engineering.github.io/Mockzilla/
+documentation: https://mockzilla.apadmi.dev/
 topics:
   - http
   - server

--- a/FlutterMockzilla/mockzilla_android/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_android/pubspec.yaml
@@ -3,10 +3,10 @@ description: The Android implementation for the mockzilla plugin.
 # x-release-please-start-version
 version: 1.2.1
 # x-release-please-end
-homepage: https://apadmi-engineering.github.io/Mockzilla/
+homepage: https://mockzilla.apadmi.dev/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues
-documentation: https://apadmi-engineering.github.io/Mockzilla/
+documentation: https://mockzilla.apadmi.dev/
 topics:
   - http
   - server

--- a/FlutterMockzilla/mockzilla_ios/ios/mockzilla_ios.podspec
+++ b/FlutterMockzilla/mockzilla_ios/ios/mockzilla_ios.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 The iOS implementation for the mockzilla plugin.
                        DESC
-  s.homepage         = 'https://apadmi-engineering.github.io/Mockzilla/'
+  s.homepage         = 'https://mockzilla.apadmi.dev/'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Apadmi Ltd.' => 'tomh@apadmi.com' }
   s.source           = { :path => '.' }

--- a/FlutterMockzilla/mockzilla_ios/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ios/pubspec.yaml
@@ -3,10 +3,10 @@ description: The iOS implementation for the mockzilla plugin.
 # x-release-please-start-version
 version: 1.2.1
 # x-release-please-end
-homepage: https://apadmi-engineering.github.io/Mockzilla/
+homepage: https://mockzilla.apadmi.dev/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues
-documentation: https://apadmi-engineering.github.io/Mockzilla/
+documentation: https://mockzilla.apadmi.dev/
 topics:
   - http
   - server

--- a/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.dart
+++ b/FlutterMockzilla/mockzilla_platform_interface/lib/src/models.dart
@@ -74,7 +74,7 @@ abstract class DashboardOptionsConfig with _$DashboardOptionsConfig {
 /// Configuration for an endpoint including how requests should be handled
 /// and desktop app presets.
 ///
-/// Please see [https://apadmi-engineering.github.io/Mockzilla/endpoints/]()
+/// Please see [https://mockzilla.apadmi.dev/endpoints/]()
 /// for more information.
 @freezed
 abstract class EndpointConfig with _$EndpointConfig {

--- a/FlutterMockzilla/mockzilla_platform_interface/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_platform_interface/pubspec.yaml
@@ -3,10 +3,10 @@ description: A common interface for the mockzilla plugin.
 # x-release-please-start-version
 version: 1.1.1
 # x-release-please-end
-homepage: https://apadmi-engineering.github.io/Mockzilla/
+homepage: https://mockzilla.apadmi.dev/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues
-documentation: https://apadmi-engineering.github.io/Mockzilla/
+documentation: https://mockzilla.apadmi.dev/
 topics:
   - http
   - server

--- a/FlutterMockzilla/mockzilla_ui_mobile/README.md
+++ b/FlutterMockzilla/mockzilla_ui_mobile/README.md
@@ -10,7 +10,7 @@ A Flutter plugin providing inbuilt UI for configuring the [Mockzilla](https://pu
 |-------------|-------------------------|-------|
 | **Support** | SDK 21+ (Target SDK 36) | 13.0+ |
 
-**Full documentation available [here!](https://apadmi-engineering.github.io/Mockzilla/mobile_ui)**
+**Full documentation available [here!](https://mockzilla.apadmi.dev/mobile_ui)**
 
 ## Setup Mockzilla
 

--- a/FlutterMockzilla/mockzilla_ui_mobile/ios/mockzilla_ui_mobile.podspec
+++ b/FlutterMockzilla/mockzilla_ui_mobile/ios/mockzilla_ui_mobile.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.description      = <<-DESC
 The iOS implementation for the mockzilla mobile ui plugin.
                        DESC
-  s.homepage         = 'https://apadmi-engineering.github.io/Mockzilla/'
+  s.homepage         = 'https://mockzilla.apadmi.dev/'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Apadmi Ltd.' => 'samdc@apadmi.com' }
   s.source           = { :path => '.' }

--- a/FlutterMockzilla/mockzilla_ui_mobile/pubspec.yaml
+++ b/FlutterMockzilla/mockzilla_ui_mobile/pubspec.yaml
@@ -3,10 +3,10 @@ description: "Embedded UI for controlling the mockzilla server at runtime"
 # x-release-please-start-version
 version: 0.0.4
 # x-release-please-end
-homepage: https://apadmi-engineering.github.io/Mockzilla/
+homepage: https://mockzilla.apadmi.dev/
 repository: https://github.com/Apadmi-Engineering/Mockzilla
 issue_tracker: https://github.com/Apadmi-Engineering/Mockzilla/issues
-documentation: https://apadmi-engineering.github.io/Mockzilla/
+documentation: https://mockzilla.apadmi.dev/
 
 environment:
   sdk: '>=3.6.0 <4.0.0'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The source code is written in Kotlin but is fully compatible with a Swift enviro
 
 ## Quick Start 🚀
 
-Please see our quick start guide and full documentation [here](https://apadmi-engineering.github.io/Mockzilla/).
+Please see our quick start guide and full documentation [here](https://mockzilla.apadmi.dev/).
 
 ## Why's it useful? 🙌
 

--- a/SwiftMockzilla/.spi.yml
+++ b/SwiftMockzilla/.spi.yml
@@ -1,3 +1,3 @@
 version: 1
 external_links:
-  documentation: "https://apadmi-engineering.github.io/Mockzilla/"
+  documentation: "https://mockzilla.apadmi.dev/"

--- a/SwiftMockzillaMobileUi/.spi.yml
+++ b/SwiftMockzillaMobileUi/.spi.yml
@@ -1,3 +1,3 @@
 version: 1
 external_links:
-  documentation: "https://apadmi-engineering.github.io/Mockzilla/"
+  documentation: "https://mockzilla.apadmi.dev/"

--- a/docs/custom_hooks.py
+++ b/docs/custom_hooks.py
@@ -12,7 +12,7 @@ def on_pre_build(config):
                 This is a debug build, to see the homepage here first run
                 `npm run build` in the homepage project directory.
 
-                Click <a target="_top" href="/Mockzilla/endpoints">here</a> to go to main docs
+                Click <a target="_top" href="/endpoints">here</a> to go to main docs
                  """, file=text_file)
     if "build" in sys.argv:
         if not os.path.isfile(index_dir):

--- a/docs/docs/browser_stack.md
+++ b/docs/docs/browser_stack.md
@@ -17,4 +17,4 @@ OkHttpClient.Builder()
 
 ### Ktor Example:
 
-See demo app example [here](https://github.com/Apadmi-Engineering/Mockzilla/blob/develop/samples/demo-android/src/main/java/com/apadmi/mockzilla/demo/Repository.kt).
+See demo app example [here](https://github.com/Apadmi-Engineering/Mockzilla/blob/develop/samples/demo-android/src/main/java/com/apadmi/mockzilla/demo/Repository.kt#L52).

--- a/docs/docs/endpoints.md
+++ b/docs/docs/endpoints.md
@@ -161,7 +161,7 @@ data class MockzillaHttpRequest(
 
 ### (2) - Artificial Latency
 
-The following can be configured globally across all endpoints [here](./dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/).
+The following can be configured globally across all endpoints [here](/dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/#1935914297%2FFunctions%2F1121797123).
 
 Network requests generally don't complete instantly. Mockzilla mimics the latency of a network and can be configured 
 either across all endpoints on the top level config, or on individual endpoints as follows:
@@ -198,7 +198,7 @@ For each individual request invocation, an artificial delay is added.
 
 ### (3) - Artificial Errors
 
-The following can be configured globally across all endpoints [here](./dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/).
+The following can be configured globally across all endpoints [here](/dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/#-1949710801%2FFunctions%2F1121797123).
 
 Mockzilla supports artificially causing network requests to fail.
 

--- a/docs/docs/homepage-assets
+++ b/docs/docs/homepage-assets
@@ -1,1 +1,1 @@
-../homepage/build/Mockzilla/homepage-assets/
+../homepage/build/homepage-assets/

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -78,13 +78,13 @@ Mockzilla is entirely driven by a config object which is used to start the serve
         ),
     );
     ```
-See [here](./endpoints/) for more information on configuring your endpoints. (Including compile-time safety!)
+See [here](/endpoints/) for more information on configuring your endpoints. (Including compile-time safety!)
 
 ### (2): Just start the server!
 
 !!! note 
     For KMP apps, even though all the configuration can be defined in Kotlin. The server should still be started directly from within native code on both platforms.
-    See the [KMP demo](https://github.com/Apadmi-Engineering/Mockzilla/tree/develop/demo-kmm) for an example.
+    See the [KMP demo](https://github.com/Apadmi-Engineering/Mockzilla/tree/develop/samples/demo-kmm) for an example.
 
 === "Android Application"
     ```kotlin
@@ -129,7 +129,7 @@ See [here](./endpoints/) for more information on configuring your endpoints. (In
 
 Mockzilla listens for calls to `http://localhost:8080/local-mock` (this should be your base url).
 
-To configure the port see [here](./dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/).
+To configure the port see [here](/dokka/mockzilla-common/com.apadmi.mockzilla.lib.models/-mockzilla-config/-builder/#581853299%2FFunctions%2F1121797123).
 
 ## Recommendation
 

--- a/docs/homepage/src/components/Footer.tsx
+++ b/docs/homepage/src/components/Footer.tsx
@@ -16,8 +16,8 @@ export function Footer() {
           <div className="space-y-4">
             <h3 className="font-semibold">Documentation</h3>
             <ul className="space-y-2 text-sm text-muted-foreground">
-              <li><a target="_top" href="/Mockzilla/endpoints" className="hover:text-foreground transition-colors">Getting Started</a></li>
-              <li><a target="_top" href="/Mockzilla/dokka" className="hover:text-foreground transition-colors">API Reference</a></li>
+              <li><a target="_top" href="/quick-start" className="hover:text-foreground transition-colors">Getting Started</a></li>
+              <li><a target="_top" href="/dokka" className="hover:text-foreground transition-colors">API Reference</a></li>
               <li><a target="_top" href="https://github.com/Apadmi-Engineering/Mockzilla/tree/develop/samples" className="hover:text-foreground transition-colors">Examples</a></li>
             </ul>
           </div>
@@ -26,7 +26,7 @@ export function Footer() {
             <h3 className="font-semibold">Community</h3>
             <ul className="space-y-2 text-sm text-muted-foreground">
               <li><a target="_top" href="https://github.com/Apadmi-Engineering/Mockzilla/" className="hover:text-foreground transition-colors">GitHub</a></li>
-              <li><a target="_top" href="/Mockzilla/contributing" className="hover:text-foreground transition-colors">Contributing</a></li>
+              <li><a target="_top" href="/contributing" className="hover:text-foreground transition-colors">Contributing</a></li>
             </ul>
           </div>
           

--- a/docs/homepage/src/components/Hero.tsx
+++ b/docs/homepage/src/components/Hero.tsx
@@ -63,7 +63,7 @@ startMockzilla(config)`}</SyntaxHighlighter>
 
                         <div className="flex flex-col sm:flex-row gap-4">
                             <Button size="lg" className="w-fit"
-                                    onClick={() => (window.top || window).location.href = "/Mockzilla/endpoints"}>
+                                    onClick={() => (window.top || window).location.href = "/quick-start"}>
                                 Get Started
                                 <ArrowRight className="ml-2 h-4 w-4"/>
                             </Button>

--- a/docs/homepage/vite.config.mjs
+++ b/docs/homepage/vite.config.mjs
@@ -20,7 +20,7 @@
     build: {
       target: 'esnext',
       outDir: 'build',
-      assetsDir: "Mockzilla/homepage-assets"
+      assetsDir: "homepage-assets"
     },
     server: {
       port: 3010,

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Mockzilla
-site_url: https://apadmi-engineering.github.io/Mockzilla
+site_url: https://mockzilla.apadmi.dev/
 repo_url: https://github.com/Apadmi-Engineering/Mockzilla
 copyright: Copyright &copy; 2025 Apadmi Ltd
 theme:

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -114,21 +114,13 @@ Publish to maven remote
 
 iOS target for the kmm demo
 
-### ios generate_xcframework
+### ios generate_framework_and_podspec
 
 ```sh
-[bundle exec] fastlane ios generate_xcframework
+[bundle exec] fastlane ios generate_framework_and_podspec
 ```
 
-Generate XCFramework
-
-### ios generate_podspec
-
-```sh
-[bundle exec] fastlane ios generate_podspec
-```
-
-Generate Podspec
+Generate Podspec and Framework
 
 ### ios publish_swift_package
 
@@ -153,14 +145,6 @@ iOS target for the lib
 ```
 
 Build and test SwiftMockzilla
-
-### ios generate_mobile_ui_framework_and_podspec
-
-```sh
-[bundle exec] fastlane ios generate_mobile_ui_framework_and_podspec
-```
-
-Generate Podspec
 
 ### ios publish_mobile_ui_swift_package
 

--- a/fastlane/fastfiles/docs.rb
+++ b/fastlane/fastfiles/docs.rb
@@ -12,7 +12,6 @@ lane :generate_docs do
         npm run build;
     ");
 
-
     # Generate Kotlin documentation
     gradle(
         tasks: [":dokkaHtmlMultiModule"],

--- a/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
@@ -30,7 +30,7 @@ kotlin {
     cocoapods {
         name = "SwiftMockzillaMobileUi"
         summary = "Embedded UI for configuring and controlling the Mockzilla server from within an app"
-        homepage = "https://apadmi-engineering.github.io/Mockzilla/"
+        homepage = "https://mockzilla.apadmi.dev/"
         framework {
             baseName = artifactName
         }

--- a/mockzilla/build.gradle.kts
+++ b/mockzilla/build.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
     cocoapods {
         name = "SwiftMockzilla"
         summary = "A solution for running and configuring a local HTTP server to mimic REST API endpoints used by your application."
-        homepage = "https://apadmi-engineering.github.io/Mockzilla/"
+        homepage = "https://mockzilla.apadmi.dev/"
         framework {
             baseName = artifactName
         }


### PR DESCRIPTION
The motivation here is to have all the hosting in Cloudflare which frees up the apadmi engineering github pages