### PR TITLE
chore: add checks that sdks are deployed with compatible dependencies

### DIFF
--- a/.github/workflows/action_deploy_mobile_ui_binaries.yml
+++ b/.github/workflows/action_deploy_mobile_ui_binaries.yml
@@ -30,9 +30,29 @@ jobs:
           if: ${{ !env.is_snapshot }}
           release-type: simple
           skip-github-pull-request: true
+  pre-deploy-checks:
+    runs-on: macos-14
+    steps:
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.0.1'
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin' # See 'Supported distributions' for available options
+          java-version: '17'
+      - name: Install dependencies
+        run: bundle install
+      - name: Deploy package to Maven Central
+        run: |
+          export GPG_TTY=$(tty)
+          bundle exec fastlane management_ui_pre_deploy_checks
+        env:
+          IS_BUILDING_FOR_DEPLOYMENT: ${{ true }}
   deploy-swift:
     environment: production
     runs-on: macos-14
+    needs: [pre-deploy-checks]
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -50,9 +70,11 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
           IOS_MOBILE_UI_DEPLOY_URL: ${{ secrets.IOS_MOBILE_UI_DEPLOY_URL }}
+          IS_BUILDING_FOR_DEPLOYMENT: ${{ true }}
   deploy-kotlin:
     environment: production
     runs-on: macos-14
+    needs: [pre-deploy-checks]
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/build-logic/src/main/kotlin/com/apadmi/mockzilla/MobileUiConfig.kt
+++ b/build-logic/src/main/kotlin/com/apadmi/mockzilla/MobileUiConfig.kt
@@ -1,5 +1,9 @@
 package com.apadmi.mockzilla
 
+import org.gradle.api.Project
+
 object MobileUiConfig {
     const val coreVersionForManagementUi = "2.4.1"
 }
+
+fun Project.isMobileUiDeployBuild() = properties["is_building_for_deployment"].toString().toBoolean()

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -85,6 +85,14 @@ Publish to maven local
 
 Publish to maven remote
 
+### management_ui_pre_deploy_checks
+
+```sh
+[bundle exec] fastlane management_ui_pre_deploy_checks
+```
+
+During deployment we don't use local packages, but for deployment we have to, so run tests against the deployed core binaries
+
 ### management_ui_pull_request
 
 ```sh

--- a/fastlane/fastfiles/management-ui.rb
+++ b/fastlane/fastfiles/management-ui.rb
@@ -94,7 +94,8 @@ end
 def createSnapshotProp(is_snapshot, version)
     {
         "is_snapshot" => is_snapshot,
-        "version" => version
+        "version" => version,
+        "is_building_for_deployment" => true
     }
 end
 
@@ -104,6 +105,17 @@ private_lane :get_mobile_ui_version_name do |options|
     version = build_gradle_text.match(version_pattern)[1]
 
     options[:is_snapshot] ? "#{version}-SNAPSHOT" : version
+end
+
+desc "During deployment we don't use local packages, but for deployment we have to, so run tests against the deployed core binaries"
+lane :management_ui_pre_deploy_checks do |options|
+    gradle(
+        tasks: [
+            ":mockzilla-management-ui:mockzilla-management-ui-common:desktopTest",
+            ":mockzilla-management-ui:mockzilla-mobile-ui:testDebugUnitTest"
+        ],
+        properties: createSnapshotProp(options[:is_snapshot], get_mobile_ui_version_name(options))
+    )
 end
 
 lane :management_ui_pull_request do

--- a/mockzilla-management-ui/mockzilla-management-ui-common/build.gradle.kts
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/build.gradle.kts
@@ -4,6 +4,7 @@ import com.apadmi.mockzilla.JavaConfig
 import com.apadmi.mockzilla.MobileUiConfig
 import com.apadmi.mockzilla.configureCommonProperties
 import com.apadmi.mockzilla.injectedVersion
+import com.apadmi.mockzilla.isMobileUiDeployBuild
 import com.apadmi.mockzilla.isSigningEnabled
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
@@ -66,9 +67,15 @@ kotlin {
             implementation(libs.kotlinx.serialization.json)
 
             /* Mockzilla Management */
-            // These are overridden in the sample apps to use local dependencies for development
-            implementation("com.apadmi:mockzilla-management:${MobileUiConfig.coreVersionForManagementUi}")
-            implementation("com.apadmi:mockzilla-common:${MobileUiConfig.coreVersionForManagementUi}")
+            if (isMobileUiDeployBuild()) {
+                //noinspection UseTomlInstead
+                implementation("com.apadmi:mockzilla-common:${MobileUiConfig.coreVersionForManagementUi}")
+                //noinspection UseTomlInstead
+                implementation("com.apadmi:mockzilla-management:${MobileUiConfig.coreVersionForManagementUi}")
+            } else {
+                implementation(project(":mockzilla-common"))
+                implementation(project(":mockzilla-management"))
+            }
 
             /* Serialization */
             implementation(libs.kotlinx.serialization.json)

--- a/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
@@ -4,6 +4,7 @@ import com.apadmi.mockzilla.JavaConfig
 import com.apadmi.mockzilla.MobileUiConfig
 import com.apadmi.mockzilla.configureCommonProperties
 import com.apadmi.mockzilla.injectedVersion
+import com.apadmi.mockzilla.isMobileUiDeployBuild
 import com.apadmi.mockzilla.isSigningEnabled
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
@@ -77,10 +78,15 @@ kotlin {
 
             /* Mockzilla Management */
             implementation(project(":mockzilla-management-ui:mockzilla-management-ui-common"))
-            //noinspection UseTomlInstead
-            implementation("com.apadmi:mockzilla-common:${MobileUiConfig.coreVersionForManagementUi}")
-            //noinspection UseTomlInstead
-            implementation("com.apadmi:mockzilla-management:${MobileUiConfig.coreVersionForManagementUi}")
+            if (isMobileUiDeployBuild()) {
+                //noinspection UseTomlInstead
+                implementation("com.apadmi:mockzilla-common:${MobileUiConfig.coreVersionForManagementUi}")
+                //noinspection UseTomlInstead
+                implementation("com.apadmi:mockzilla-management:${MobileUiConfig.coreVersionForManagementUi}")
+            } else {
+                implementation(project(":mockzilla-common"))
+                implementation(project(":mockzilla-management"))
+            }
 
             /* Serialization */
             implementation(libs.kotlinx.serialization.json)


### PR DESCRIPTION
This allows us to have the following:
1. Local development using project dependencies so changes in mockzilla-common for example is immediately testable in sample apps and via mobile ui
2. Mobile ui version isn't dependent on the core module dependencies.

Without this change though it's possible someone could try to deploy the mobile-ui without a compatible deployed version of the modules it depends on. This ensure this doesn't happen.