### PR TITLE
fix: fix ios framework and android experimental compose usage

### DIFF
--- a/.github/workflows/action_deploy_binaries.yml
+++ b/.github/workflows/action_deploy_binaries.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:

--- a/.github/workflows/action_deploy_mobile_ui_binaries.yml
+++ b/.github/workflows/action_deploy_mobile_ui_binaries.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   deploy-flutter:
     needs: [deploy-kotlin, deploy-swift]
+    if: ${{ github.ref_type != 'branch' }}
     permissions:
       id-token: write
     uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
@@ -35,7 +36,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
@@ -56,7 +57,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
@@ -78,7 +79,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
@@ -88,7 +89,7 @@ jobs:
       - name: Install dependencies
         run: bundle install
       - name: Deploy package to Maven Central
-        run: | 
+        run: |
           export GPG_TTY=$(tty)
           bundle exec fastlane publish_mobile_ui_to_maven is_snapshot:$is_snapshot
         env:

--- a/.github/workflows/action_pull_request.yml
+++ b/.github/workflows/action_pull_request.yml
@@ -111,7 +111,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - uses: subosito/flutter-action@v2
         with:
@@ -131,7 +131,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - uses: actions/setup-java@v5
         with:
@@ -152,7 +152,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - name: Setup fastlane
         run: bundle install
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - name: Setup fastlane
         run: bundle install
@@ -180,7 +180,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - name: Setup fastlane
         run: bundle install
@@ -194,7 +194,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - name: Setup fastlane
         run: bundle install
@@ -208,7 +208,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - name: Setup fastlane
         run: bundle install
@@ -222,7 +222,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - name: Setup fastlane
         run: bundle install
@@ -236,7 +236,7 @@ jobs:
     steps:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.0.1'
+          xcode-version: '15.4.0'
       - uses: actions/checkout@v5
       - name: Setup fastlane
         run: bundle install

--- a/FlutterMockzilla/mockzilla_ui_mobile/ios/mockzilla_ui_mobile/Package.swift
+++ b/FlutterMockzilla/mockzilla_ui_mobile/ios/mockzilla_ui_mobile/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "mockzilla_ui_mobile",
+            name: "mockzillauimobile",
             dependencies: ["SwiftMockzillaMobileUi"],
             resources: []
         )

--- a/SwiftMockzillaMobileUi/Package.swift
+++ b/SwiftMockzillaMobileUi/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "SwiftMockzillaMobileUi",
-            targets: ["SwiftMockzillaMobileUi", "mockzilla_mobile_ui"]),
+            targets: ["SwiftMockzillaMobileUi", "mockzillamobileui"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -21,13 +21,13 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SwiftMockzillaMobileUi",
-            dependencies: ["mockzilla_mobile_ui"]),
+            dependencies: ["mockzillamobileui"]),
         .testTarget(
             name: "SwiftMockzillaMobileUiTests",
-            dependencies: ["SwiftMockzillaMobileUi", "mockzilla_mobile_ui"]),
+            dependencies: ["SwiftMockzillaMobileUi", "mockzillamobileui"]),
         .binaryTarget(
-            name: "mockzilla_mobile_ui",
-            path: "./mockzilla_mobile_ui.xcframework"
+            name: "mockzillamobileui",
+            path: "./mockzillamobileui.xcframework"
         ),
     ]
 )

--- a/SwiftMockzillaMobileUi/Sources/SwiftMockzillaMobileUi/SwiftMockzillaMobileUi.swift
+++ b/SwiftMockzillaMobileUi/Sources/SwiftMockzillaMobileUi/SwiftMockzillaMobileUi.swift
@@ -1,5 +1,10 @@
-import mockzilla_mobile_ui
+import mockzillamobileui
+import UIKit
 
 public func launchManagementUiSwift() {
     Launcher_iosKt.launchManagementUi()
+}
+
+public func createManagementUiViewControllerSwift(onClose: @escaping () -> Void) -> UIViewController {
+    return Launcher_iosKt.createManagementUiViewController(onClose: onClose)
 }

--- a/docs/docs/desktop/overview.md
+++ b/docs/docs/desktop/overview.md
@@ -8,6 +8,17 @@ It allows manipulation of the mock data being returned by Mockzilla on your devi
     You **must** be using the same Wifi network on your device running Mockzilla and the device running
     the desktop app.
 
+## Preparation
+
+On iOS add the following to your Info.plist
+
+```xml
+<key>NSBonjourServices</key>
+<array>
+  <string>_mockzilla._tcp</string>
+</array>
+```
+
 ### (1): Connect your device
 
 Your device should be automatically discovered by Mockzilla (you may need to restart the app on your device).

--- a/docs/docs/mobile_ui.md
+++ b/docs/docs/mobile_ui.md
@@ -48,13 +48,31 @@ You can do this from a button click or any trigger in your app code.
     ```kotlin
     import com.apadmi.mockzilla.mobile.ui.launchManagementUi
 
+    /// Android Target ///
     launchManagementUi(context /* Activity Context */)
+
+    /// iOS Target ///
+    launchManagementUi()
+
+    // Or 
+
+    // Handle the ViewController directly
+    createManagementUiViewController(onClose = { 
+        // Dismiss the ViewController
+    }
     ```
 === "Swift"
     ```swift
     import SwiftMockzillaMobileUi
 
     launchManagementUiSwift()
+
+    // Or
+
+    // Handle the ViewController directly
+    createManagementUiViewControllerSwift {
+      // Dismiss the ViewController
+    }
     ```
 === "Flutter"
     ```dart

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -37,6 +37,36 @@
     mockzilla: <version>
     ```
 
+## Enable local plaintext traffic
+
+=== "Android"
+    Add both `localhost` and `127.0.0.1` to your [network_security_config.xml](https://developer.android.com/privacy-and-security/security-config).
+    (We recommend having a separate config for production which does not have these overrides)
+    ```xml
+    <?xml version="1.0" encoding="utf-8"?>
+    <network-security-config>
+        <base-config>
+            <trust-anchors>
+                <certificates src="system" />
+                <certificates src="user" />
+            </trust-anchors>
+        </base-config>
+        <domain-config cleartextTrafficPermitted="true">
+            <domain includeSubdomains="true">localhost</domain>
+            <domain includeSubdomains="true">127.0.0.1</domain>
+        </domain-config>
+    </network-security-config>
+    ```
+=== "iOS"
+    Add the following to your info.plist.
+    ```xml
+    <key>NSAppTransportSecurity</key>
+    <dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+    </dict>
+    ```
+
 ## Starting The Server
 
 Mockzilla is entirely driven by a config object which is used to start the server.

--- a/fastlane/fastfiles/management-ui.rb
+++ b/fastlane/fastfiles/management-ui.rb
@@ -9,7 +9,7 @@ platform :ios do
         )
 
         # Copy the Podspec to where the publish lane can find it
-        sh("cp -rf #{lane_context[:repo_root]}/mockzilla-management-ui/mockzilla-mobile-ui/build/cocoapods/publish/release/mockzilla_mobile_ui.xcframework #{lane_context[:repo_root]}/SwiftMockzillaMobileUi")
+        sh("cp -rf #{lane_context[:repo_root]}/mockzilla-management-ui/mockzilla-mobile-ui/build/cocoapods/publish/release/mockzillamobileui.xcframework #{lane_context[:repo_root]}/SwiftMockzillaMobileUi")
         sh("cp -rf #{lane_context[:repo_root]}/mockzilla-management-ui/mockzilla-mobile-ui/build/cocoapods/publish/release/SwiftMockzillaMobileUi.podspec #{lane_context[:repo_root]}/SwiftMockzillaMobileUi")
 
         # Remove the resources line from Podspec since it causes it to fail validation (and it's not used)
@@ -41,7 +41,7 @@ platform :ios do
             cp -r #{lane_context[:repo_root]}/SwiftMockzillaMobileUi/ .;
 
             git add .;
-            git add --force mockzilla_mobile_ui.xcframework;
+            git add --force mockzillamobileui.xcframework;
             git add --force SwiftMockzillaMobileUi.podspec;
             git commit -m "Updating Package #{get_mobile_ui_version_name(options)}";
             git push;

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsWidget.kt
@@ -2,10 +2,10 @@
 
 package com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.details
 
-import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -20,14 +20,12 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -106,7 +104,6 @@ fun EndpointDetailsWidget(
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun EndpointDetailsWidgetContent(
     state: EndpointDetailsViewModel.State,
@@ -223,7 +220,6 @@ private fun EndpointDetailsWidgetPreview() = PreviewSurface {
     EndpointDetailsWidgetPreviewContent()
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
 private fun EndpointDetailsResponseBody(
     modifier: Modifier = Modifier,
@@ -243,23 +239,24 @@ private fun EndpointDetailsResponseBody(
     Spacer(Modifier.height(4.dp))
     var pickingStatusCode by remember { mutableStateOf(false) }
 
-    ExposedDropdownMenuBox(
-        expanded = pickingStatusCode,
-        onExpandedChange = { pickingStatusCode = it },
+    Box(
         modifier = Modifier.padding(horizontal = 8.dp),
     ) {
-        TextField(
-            value = statusCode
-                ?.let { strings.widgets.endpointDetails.statusCodeLabel(it) }
-                ?: strings.widgets.endpointDetails.noOverrideStatusCode,
-            // TODO: Work out how to also let user type in custom status number
-            onValueChange = {},
-            modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable).fillMaxWidth(),
-            readOnly = true,
-            singleLine = true,
-            label = { Text(text = strings.widgets.endpointDetails.statusCode) },
-        )
-        ExposedDropdownMenu(
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                .clickable(onClick = {
+                    pickingStatusCode = !pickingStatusCode
+                })
+        ) {
+            // TODO: Let user type in custom status number
+            // Temp before proper refactor
+            Text(text = strings.widgets.endpointDetails.statusCode)
+            Text(
+                text = statusCode
+                    ?.let { strings.widgets.endpointDetails.statusCodeLabel(it) }
+                    ?: strings.widgets.endpointDetails.noOverrideStatusCode)
+        }
+        DropdownMenu(
             expanded = pickingStatusCode,
             onDismissRequest = { pickingStatusCode = false },
         ) {
@@ -484,7 +481,6 @@ private fun Settings(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun HeadersEditor(
     headers: List<Pair<String, String>>?,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -37,7 +36,6 @@ import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
 import io.ktor.http.HttpStatusCode
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
-import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
 @Composable
@@ -85,7 +83,6 @@ fun MonitorLogDetailsContent(
     } ?: MonitorLogDetailsEmptyContent()
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalTime::class)
 @Composable
 fun LogDetailsContent(
     logDetail: LogEvent,

--- a/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
@@ -22,6 +22,9 @@ plugins {
 
 val artifactName = "mockzilla-mobile-ui"
 
+// Kotlin changes `-` for `_` in framework names which breaks appstore uploads
+val xcFrameworkName = "mockzillamobileui"
+
 kotlin {
     // Managed automatically by release-please PRs
     version = project.injectedVersion() ?: "0.0.4" // x-release-please-version
@@ -34,12 +37,12 @@ kotlin {
         summary = "Embedded UI for configuring and controlling the Mockzilla server from within an app"
         homepage = "https://mockzilla.apadmi.dev/"
         framework {
-            baseName = artifactName
+            baseName = xcFrameworkName
         }
         license = "{:type => 'MIT', :file => 'LICENSE'}"
         // This is explicitly `getVersion()` and not `version`! The latter is shadowed in `cocoapods` scope.
         source = "{ :git => 'https://github.com/Apadmi-Engineering/SwiftMockzillaMobileUi.git', :tag => 'v${project.version}' }"
-        extraSpecAttributes["vendored_frameworks"] = "'mockzilla_mobile_ui.xcframework'"
+        extraSpecAttributes["vendored_frameworks"] = "'${xcFrameworkName}.xcframework'"
         extraSpecAttributes["source_files"] = "'Sources/SwiftMockzillaMobileUi/SwiftMockzillaMobileUi.swift'"
         extraSpecAttributes["swift_version"] = "'5.9.2'"
 
@@ -53,7 +56,7 @@ kotlin {
         iosSimulatorArm64()
     ).forEach {
         it.binaries.framework {
-            baseName = artifactName
+            baseName = xcFrameworkName
             xcf.add(this)
         }
     }

--- a/mockzilla-management-ui/mockzilla-mobile-ui/src/commonMain/kotlin/com/apadmi/mockzilla/mobile/ui/MobileAppRoot.kt
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/src/commonMain/kotlin/com/apadmi/mockzilla/mobile/ui/MobileAppRoot.kt
@@ -2,22 +2,28 @@
 
 package com.apadmi.mockzilla.mobile.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -37,7 +43,6 @@ import com.apadmi.mockzilla.ui.ui.common.widgets.deviceconnection.UnsupportedDev
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.details.EndpointDetailsWidget
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.EndpointsWidget
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun MobileAppRoot(
     strings: Strings = LocalStrings.current,
@@ -51,27 +56,32 @@ internal fun MobileAppRoot(
         .size > 2
 
     Column {
-        TopAppBar(
-            title = { /* No title */ },
-            navigationIcon = {
-                if (showBackButton) {
-                    IconButton(onClick = navController::navigateUp) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = strings.common.backDescription
-                        )
-                    }
-                }
-            },
-            actions = {
-                IconButton(onClick = onClose) {
+        Row(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .statusBarsPadding()
+                .height(64.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (showBackButton) {
+                IconButton(onClick = navController::navigateUp) {
                     Icon(
-                        imageVector = Icons.Filled.Close,
-                        contentDescription = strings.common.closeDescription
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        tint = MaterialTheme.colorScheme.onBackground,
+                        contentDescription = strings.common.backDescription
                     )
                 }
             }
-        )
+            Spacer(Modifier.weight(1f))
+
+            IconButton(onClick = onClose) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    tint = MaterialTheme.colorScheme.onBackground,
+                    contentDescription = strings.common.closeDescription
+                )
+            }
+        }
 
         when (val currentState = state) {
             is State.Connected -> ConnectedState(

--- a/mockzilla-management-ui/mockzilla-mobile-ui/src/iosMain/kotlin/com/apadmi/mockzilla/mobile/ui/Launcher.ios.kt
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/src/iosMain/kotlin/com/apadmi/mockzilla/mobile/ui/Launcher.ios.kt
@@ -8,17 +8,21 @@ import org.koin.dsl.module
 import platform.UIKit.*
 
 fun launchManagementUi() {
+    val root = UIApplication.sharedApplication.keyWindow?.rootViewController
+        ?: throw IllegalStateException("No root ViewController found, cannot push Mockzilla UI.")
+    val vc = createManagementUiViewController {
+        root.dismissViewControllerAnimated(true, null)
+    }
+
+    root.presentViewController(vc, animated = true, completion = null)
+}
+
+fun createManagementUiViewController(onClose: () -> Unit): UIViewController {
     startMockzillaMobileUiKoin(module {
         single { FileIo() }
     })
 
-    val root = UIApplication.sharedApplication.keyWindow?.rootViewController
-        ?: throw IllegalStateException("No root ViewController found, cannot push mockzilla UI.")
-    val controller = ComposeUIViewController(configure = { enforceStrictPlistSanityCheck = false }) {
-        MobileAppRoot(onClose = {
-            root.dismissViewControllerAnimated(true) { }
-        })
+    return ComposeUIViewController(configure = { enforceStrictPlistSanityCheck = false }) {
+        MobileAppRoot(onClose = onClose)
     }
-
-    root.presentViewController(controller, animated = true, completion = null)
 }

--- a/samples/demo-ios/demo-ios.xcodeproj/project.pbxproj
+++ b/samples/demo-ios/demo-ios.xcodeproj/project.pbxproj
@@ -8,7 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		830304BF2934DC8900847F4B /* MockServerConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830304BE2934DC8900847F4B /* MockServerConfig.swift */; };
-		830AC9A42E869F1C00CA9057 /* SwiftMockzillaMobileUi in Frameworks */ = {isa = PBXBuildFile; productRef = 830AC9A32E869F1C00CA9057 /* SwiftMockzillaMobileUi */; };
+		830ED5572E97E1DF00D9F90C /* SwiftMockzillaMobileUi in Frameworks */ = {isa = PBXBuildFile; productRef = 830ED5562E97E1DF00D9F90C /* SwiftMockzillaMobileUi */; };
+		830ED5612E97F6D400D9F90C /* SwiftMockzillaMobileUi in Frameworks */ = {isa = PBXBuildFile; productRef = 830ED5602E97F6D400D9F90C /* SwiftMockzillaMobileUi */; };
 		831D0FAB2B5191CD0016BD1D /* SwiftMockzilla in Frameworks */ = {isa = PBXBuildFile; productRef = 831D0FAA2B5191CD0016BD1D /* SwiftMockzilla */; };
 		83C94E9A290975E000D7BCCD /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C94E99290975E000D7BCCD /* AppDelegate.swift */; };
 		83C94E9C290975E000D7BCCD /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C94E9B290975E000D7BCCD /* SceneDelegate.swift */; };
@@ -58,7 +59,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				831D0FAB2B5191CD0016BD1D /* SwiftMockzilla in Frameworks */,
-				830AC9A42E869F1C00CA9057 /* SwiftMockzillaMobileUi in Frameworks */,
+				830ED5612E97F6D400D9F90C /* SwiftMockzillaMobileUi in Frameworks */,
+				830ED5572E97E1DF00D9F90C /* SwiftMockzillaMobileUi in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,7 +174,8 @@
 			name = "demo-ios";
 			packageProductDependencies = (
 				831D0FAA2B5191CD0016BD1D /* SwiftMockzilla */,
-				830AC9A32E869F1C00CA9057 /* SwiftMockzillaMobileUi */,
+				830ED5562E97E1DF00D9F90C /* SwiftMockzillaMobileUi */,
+				830ED5602E97F6D400D9F90C /* SwiftMockzillaMobileUi */,
 			);
 			productName = "demo-ios";
 			productReference = 83C94E96290975E000D7BCCD /* demo-ios.app */;
@@ -248,7 +251,7 @@
 			mainGroup = 83C94E8D290975E000D7BCCD;
 			packageReferences = (
 				831D0FA92B5191CD0016BD1D /* XCRemoteSwiftPackageReference "SwiftMockzilla" */,
-				830AC9A22E869C8E00CA9057 /* XCRemoteSwiftPackageReference "SwiftMockzillaMobileUi" */,
+				830ED55F2E97F6D400D9F90C /* XCRemoteSwiftPackageReference "SwiftMockzillaMobileUi" */,
 			);
 			productRefGroup = 83C94E97290975E000D7BCCD /* Products */;
 			projectDirPath = "";
@@ -638,12 +641,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		830AC9A22E869C8E00CA9057 /* XCRemoteSwiftPackageReference "SwiftMockzillaMobileUi" */ = {
+		830ED55F2E97F6D400D9F90C /* XCRemoteSwiftPackageReference "SwiftMockzillaMobileUi" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Apadmi-Engineering/SwiftMockzillaMobileUi/";
 			requirement = {
 				kind = revision;
-				revision = 14af371e2dc676c76be0a6deb072998db97c588d;
+				revision = ba06b3820b190593abddc7e9581a11f0ffd8278b;
 			};
 		};
 		831D0FA92B5191CD0016BD1D /* XCRemoteSwiftPackageReference "SwiftMockzilla" */ = {
@@ -657,9 +660,13 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		830AC9A32E869F1C00CA9057 /* SwiftMockzillaMobileUi */ = {
+		830ED5562E97E1DF00D9F90C /* SwiftMockzillaMobileUi */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 830AC9A22E869C8E00CA9057 /* XCRemoteSwiftPackageReference "SwiftMockzillaMobileUi" */;
+			productName = SwiftMockzillaMobileUi;
+		};
+		830ED5602E97F6D400D9F90C /* SwiftMockzillaMobileUi */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 830ED55F2E97F6D400D9F90C /* XCRemoteSwiftPackageReference "SwiftMockzillaMobileUi" */;
 			productName = SwiftMockzillaMobileUi;
 		};
 		831D0FAA2B5191CD0016BD1D /* SwiftMockzilla */ = {

--- a/samples/demo-ios/demo-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/samples/demo-ios/demo-ios.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,7 +14,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Apadmi-Engineering/SwiftMockzillaMobileUi/",
       "state" : {
-        "revision" : "14af371e2dc676c76be0a6deb072998db97c588d"
+        "revision" : "ba06b3820b190593abddc7e9581a11f0ffd8278b"
       }
     }
   ],

--- a/samples/demo-ios/demo-ios/MockServerConfig.swift
+++ b/samples/demo-ios/demo-ios/MockServerConfig.swift
@@ -14,6 +14,7 @@ extension MockzillaConfig {
     
     static func createConfig() -> MockzillaConfig {
         MockzillaConfig.Builder()
+           .setPort(port: 8034)
            .setFailureProbabilityPercentage(percentage: 0)
            .setIsReleaseModeEnabled(isRelease: false) // Change to true to test release mode
            .setMeanDelayMillis(delay: 100)


### PR DESCRIPTION
- Using experimental APIs in compose causes crashes on non compatible compose versions.
- iOS frameworks can't have underscores in the name so remove those