### PR TITLE
chore: remove iOS crash and replace with warning

### DIFF
--- a/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
+++ b/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/Mockzilla.kt
@@ -1,7 +1,7 @@
 package com.apadmi.mockzilla.lib
 
 import com.apadmi.mockzilla.lib.internal.discovery.ZeroConfDiscoveryServiceImpl
-import com.apadmi.mockzilla.lib.internal.discovery.validateInfoPlistOrThrow
+import com.apadmi.mockzilla.lib.internal.discovery.validateInfoPlist
 import com.apadmi.mockzilla.lib.internal.persistance.KeychainSettings
 import com.apadmi.mockzilla.lib.internal.utils.FileIo
 import com.apadmi.mockzilla.lib.internal.utils.extractMetaData
@@ -17,7 +17,7 @@ import com.apadmi.mockzilla.lib.models.PortConflictException
  */
 @Throws(PortConflictException::class)
 fun startMockzilla(config: MockzillaConfig): MockzillaRuntimeParams {
-    config.validateInfoPlistOrThrow()
+    config.validateInfoPlist()
 
     return startMockzilla(
         config = config,

--- a/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/InfoPlistValidation.kt
+++ b/mockzilla/src/iosMain/kotlin/com/apadmi/mockzilla/lib/internal/discovery/InfoPlistValidation.kt
@@ -10,7 +10,7 @@ import platform.Foundation.NSException
 import platform.Foundation.containsObject
 import platform.Foundation.raise
 
-fun MockzillaConfig.validateInfoPlistOrThrow() {
+internal fun MockzillaConfig.validateInfoPlist() {
     if (!isNetworkDiscoveryEnabled) {
         return
     }
@@ -18,7 +18,7 @@ fun MockzillaConfig.validateInfoPlistOrThrow() {
     val infoDictionary = NSBundle.mainBundle.infoDictionary!!
     val bonjourEntry = infoDictionary["NSBonjourServices"] as? NSArray
     if (bonjourEntry == null || !bonjourEntry.containsObject(ZeroConfConfig.serviceType)) {
-        Logger.e {
+        Logger.w {
             """
                 👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
                 --------------------------------------------------------------------------------
@@ -39,7 +39,5 @@ fun MockzillaConfig.validateInfoPlistOrThrow() {
                 ☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝️☝
             """.trimIndent()
         }
-        @OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
-        NSException.raise("Missing Bonjour entry in Info.plist. See above instructions", "", null)
     }
 }


### PR DESCRIPTION
On balance, this is more likely to annoy people than be actually useful