### PR TITLE
feat: Make global controls FAB floating

### DIFF
--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 
 import com.apadmi.mockzilla.lib.models.EndpointConfiguration.*
 import com.apadmi.mockzilla.ui.di.utils.getViewModel
@@ -49,14 +50,34 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 
 import org.koin.core.parameter.parametersOf
 
+@Composable
+fun EndpointsWidget(
+    device: Device,
+    onEndpointClicked: (Key) -> Unit,
+    onGlobalControlsClicked: () -> Unit
+) {
+    val viewModel = getViewModel<EndpointsViewModel>(key = device.toString()) {
+        parametersOf(device)
+    }
+    val state by viewModel.state.collectAsState()
+
+    EndpointsWidgetContent(
+        state = state,
+        onFilterUpdate = viewModel::onFilterChanged,
+        onEndpointClicked = onEndpointClicked,
+        onGlobalControlsClicked = onGlobalControlsClicked
+    )
+}
+
 @Suppress("MAGIC_NUMBER")
 @Composable
-private fun ColumnScope.EndpointsList(
+private fun EndpointsList(
     state: EndpointsViewModel.State.EndpointsList,
     onEndpointClicked: (Key) -> Unit,
-    onGlobalControlsClicked: () -> Unit,
     onFilterUpdate: (String) -> Unit,
     strings: Strings = LocalStrings.current
+) = Column(
+    modifier = Modifier.verticalScroll(rememberScrollState())
 ) {
     FilterTextField(
         value = state.filter,
@@ -83,38 +104,6 @@ private fun ColumnScope.EndpointsList(
         )
         Spacer(modifier = Modifier.height(8.dp))
     }
-
-    Spacer(modifier = Modifier.weight(1f))
-    FloatingActionButton(
-        modifier = Modifier
-            .align(Alignment.End)
-            .padding(end = 8.dp),
-        onClick = onGlobalControlsClicked,
-    ) {
-        Icon(
-            imageVector = Icons.Filled.Settings,
-            contentDescription = null
-        )
-    }
-}
-
-@Composable
-fun EndpointsWidget(
-    device: Device,
-    onEndpointClicked: (Key) -> Unit,
-    onGlobalControlsClicked: () -> Unit
-) {
-    val viewModel = getViewModel<EndpointsViewModel>(key = device.toString()) {
-        parametersOf(device)
-    }
-    val state by viewModel.state.collectAsState()
-
-    EndpointsWidgetContent(
-        state = state,
-        onFilterUpdate = viewModel::onFilterChanged,
-        onEndpointClicked = onEndpointClicked,
-        onGlobalControlsClicked = onGlobalControlsClicked
-    )
 }
 
 @Suppress("MAGIC_NUMBER")
@@ -237,21 +226,35 @@ private fun EndpointsWidgetContent(
     onFilterUpdate: (String) -> Unit,
     onEndpointClicked: (Key) -> Unit,
     onGlobalControlsClicked: () -> Unit
-) = Column(
+) = Box(
     modifier = Modifier
         .fillMaxSize()
         .background(color = MaterialTheme.colorScheme.background)
-        .verticalScroll(rememberScrollState())
         .padding(horizontal = 12.dp, vertical = 15.dp)
 ) {
     when (state) {
-        EndpointsViewModel.State.Loading -> CircularProgressIndicator()
-        is EndpointsViewModel.State.EndpointsList -> EndpointsList(
-            state = state,
-            onEndpointClicked = onEndpointClicked,
-            onGlobalControlsClicked = onGlobalControlsClicked,
-            onFilterUpdate = onFilterUpdate
+        EndpointsViewModel.State.Loading -> CircularProgressIndicator(
+            modifier = Modifier.fillMaxSize()
         )
+        is EndpointsViewModel.State.EndpointsList -> {
+            EndpointsList(
+                state = state,
+                onEndpointClicked = onEndpointClicked,
+                onFilterUpdate = onFilterUpdate
+            )
+            FloatingActionButton(
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .align(Alignment.BottomEnd)
+                    .zIndex(1f),
+                onClick = onGlobalControlsClicked,
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = null
+                )
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Makes the global controls FAB floating on the endpoints list screen - this stops the user having to scroll to the end of the list when there are many endpoints

<img width="260" height="600" alt="Screenshot_20251017_105543" src="https://github.com/user-attachments/assets/45db80fb-ef93-4a2e-a526-44642144e4c9" />
