### PR TITLE
Feature/fuzzy endpoints search

### DIFF
--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/engine/filter/FuzzyFilter.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/engine/filter/FuzzyFilter.kt
@@ -1,0 +1,138 @@
+package com.apadmi.mockzilla.ui.engine.filter
+
+import kotlin.math.max
+import kotlin.math.min
+
+data object FuzzyFilter {
+    /**
+     * Filters a list of items to only return items matching
+     * the filter exactly or with minor edits, sorted by the
+     * number of edits required.
+     *
+     * @param list List of items
+     * @param filter Filter string
+     * @param keySelector String selector to compare against filter string
+     *     for each item
+     */
+    fun <T> filter(
+        list: List<T>,
+        filter: String,
+        keySelector: (T) -> String,
+    ): List<T> {
+        @Suppress("IDENTIFIER_LENGTH")
+        val f = filter.lowercase()
+        return list
+            .map { item ->
+                val target = keySelector(item).lowercase()
+                val exactMatch = target.contains(f)
+                if (exactMatch) {
+                    item to 0
+                } else {
+                    item to distance(filter = f, target = target)
+                }
+            }
+            // Set a maximum distance based on the length of the filter string,
+            // up to a maximum of 2 edits allowed to be considered a match for
+            // longer filter strings.
+            .filter { (_, distance) -> distance < min(max(1, f.length / 2), 3) }
+            .sortedBy { (_, distance) -> distance }
+            .map { (item, _) -> item }
+    }
+
+    /**
+     * Returns the smallest number of additions, deletions or substitutions
+     * required to convert the filter string to the target string, or any
+     * substring of the target string. An identical match returns 0 and
+     * a completely unrelated filter string will return the length of
+     * the longer string.
+     *
+     * This algorithm is a modified Local Levenshtein distance described
+     * in the following research paper: https://arxiv.org/pdf/2211.02767.pdf
+     */
+    private fun distance(
+        filter: String,
+        target: String,
+    ): Int {
+        if (filter.isEmpty()) {
+            // Trivial match to 0 length substring in the target string
+            return 0
+        }
+        if (target.isEmpty()) {
+            // Trivial deletions to remove every character in the filter
+            // string to match the 0 length target string.
+            return filter.length
+        }
+
+        // If we had a matrix of 1 more rows than the length of the filter
+        // string and 1 more columns than the length of the target string, we
+        // could already fill in some of the edit distances to substrings of
+        // each. "" trivially matches any target substring, "F" would require
+        // 1 deletion to match "", whereas "FIL" would require 3 deletions to
+        // match "" and so on.
+        // - T A R G E T
+        // - 0 0 0 0 0 0 0
+        // F 1 ? ? ? ? ? ?
+        // I 2 ? ? ? ? ? ?
+        // L 3 ? ? ? ? ? ?
+        // T 4 ? ? ? ? ? ?
+        // E 5 ? ? ? ? ? ?
+        // R 6 ? ? ? ? ? ?
+
+        // We can fill in the rest of the matrix iteratively, and only need
+        // to hold two rows in memory at a given time, since the algorithm
+        // only needs to look at the previous distances in a row and the prior
+        // row to fill in each of the remaining values.
+
+        // Initialise the matrix row for matching "" to the target string, which
+        // we consider an exact match since "" is always a substring of anything.
+        var previousEditDistances = MutableList(target.length + 1) { 0 }
+
+        for (row in filter.indices) {
+            // We will work out the next row, and we know that the first column here
+            // will be a distance equal to the number of characters that we have to delete
+            // from the substring of our filter string to match against "".
+            val currentEditDistances = MutableList(target.length + 1) { 0 }
+            currentEditDistances[0] = row + 1
+
+            for (column in target.indices) {
+                // We now determine the value of the other columns in this row, looking
+                // at the previous row and the values in the earlier columns to determine
+                // the cost of the 3 ways we could adjust the filter string, and taking
+                // the lowest cost each time.
+                currentEditDistances[column + 1] = listOf(
+                    // We could delete a character from the filter string. The prior
+                    // row at this same column has the cost to match the target string for a
+                    // filter string that is one character less than the one we're looking
+                    // at, so the cost for this row and column is one greater.
+                    previousEditDistances[column + 1] + 1,
+
+                    // We could insert a character into the filter string. The prior
+                    // column at this same row has the cost to match a substring of the
+                    // target string that was one fewer characters, so we can insert the
+                    // character at a cost of one more edit.
+                    currentEditDistances[column] + 1,
+
+                    // We could substitute a character. If the character at this
+                    // point in both substrings is the same, this has no cost beyond
+                    // what we already paid in the prior row to match a substring of
+                    // the target string with a filter substring that was one shorter
+                    // than what we have now.
+                    if (filter[row] == target[column]) {
+                        previousEditDistances[column]
+                    } else {
+                        previousEditDistances[column] + 1
+                    },
+                ).min()
+            }
+
+            // Having calculated this entire row, we can replace the
+            // previous row with it and loop till we finish with the
+            // costs for the last row for the entire filter string.
+            previousEditDistances = currentEditDistances
+        }
+
+        // We return the fewest number of edits that will match
+        // any substring of the target with our filter string.
+        return previousEditDistances.min()
+    }
+}

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetViewModel.kt
@@ -262,21 +262,25 @@ class CreateEditPresetViewModel(
 // Used for backward compatibility so that old versions of the Mockzilla SDK used with new desktop app
 // where they're not sending the `appliedPresetOverride` field.
 internal fun SerializableEndpointConfig.deriveLegacyPreset(): DashboardOverridePreset? {
-    val response =  PartialMockzillaHttpResponse(
+    val response = PartialMockzillaHttpResponse(
         statusCode = defaultStatus,
         headers = defaultHeaders,
         body = defaultBody
-    ).takeIf { listOf(defaultStatus, defaultHeaders, defaultBody).any {
-        it != null }
-    } ?:  PartialMockzillaHttpResponse(
+    ).takeIf {
+        listOf(defaultStatus, defaultHeaders, defaultBody).any {
+            it != null
+        }
+    } ?: PartialMockzillaHttpResponse(
         statusCode = errorStatus,
         headers = errorHeaders,
         body = errorBody
-    ).takeIf { listOf(errorStatus, errorHeaders, errorBody).any {
-        it != null }
+    ).takeIf {
+        listOf(errorStatus, errorHeaders, errorBody).any {
+            it != null
+        }
     }
 
-    if (response != null) {
+    response?.let {
         return DashboardOverridePreset(
             name = "Derived preset",
             description = null,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsViewModel.kt
@@ -3,7 +3,6 @@ package com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.details
 import com.apadmi.mockzilla.lib.internal.models.SerializableEndpointConfig
 import com.apadmi.mockzilla.lib.models.DashboardOverridePreset
 import com.apadmi.mockzilla.lib.models.EndpointConfiguration
-import com.apadmi.mockzilla.lib.models.PartialMockzillaHttpResponse
 import com.apadmi.mockzilla.management.MockzillaManagement
 import com.apadmi.mockzilla.ui.engine.device.Device
 import com.apadmi.mockzilla.ui.engine.events.EventBus

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
@@ -9,6 +9,7 @@ import com.apadmi.mockzilla.ui.engine.filter.FuzzyFilter
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.EndpointsViewModel.State
 import com.apadmi.mockzilla.ui.viewmodel.ViewModel
 
+import kotlin.collections.filter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter
@@ -39,7 +40,7 @@ class EndpointsViewModel(
                 val filter = currentState?.filter ?: ""
                 State.EndpointsList(
                     allEndpoints = list.map {
-                        State.EndpointConfigItem(
+                        State.EndpointConfig(
                             key = it.key,
                             name = it.name,
                             fail = it.shouldFail == true,
@@ -72,45 +73,25 @@ class EndpointsViewModel(
          * @property name
          * @property fail
          * @property overriddenProperties
-         * @property display
          */
         data class EndpointConfig(
             val key: EndpointConfiguration.Key,
             val name: String,
             val fail: Boolean,
             val overriddenProperties: List<EndpointProperties>,
-            val display: Boolean,
         )
 
         /**
-         * @property key
-         * @property name
-         * @property fail
-         * @property overriddenProperties
-         */
-        data class EndpointConfigItem(
-            val key: EndpointConfiguration.Key,
-            val name: String,
-            val fail: Boolean,
-            val overriddenProperties: List<EndpointProperties>,
-        ) {
-            fun withDisplay(display: Boolean): EndpointConfig = EndpointConfig(
-                key = key,
-                name = name,
-                fail = fail,
-                overriddenProperties = overriddenProperties,
-                display = display
-            )
-        }
-
-        /**
-         * @property allEndpoints
-         * @property filter
+         * @property allEndpoints Endpoints list before applying the filter string
+         * @property filter Filter string
          */
         data class EndpointsList(
-            private val allEndpoints: List<EndpointConfigItem>,
+            val allEndpoints: List<EndpointConfig>,
             val filter: String,
         ) : State() {
+            /**
+             * Filtered endpoints
+             */
             val endpoints: List<EndpointConfig> = filterEndpoints(filter, allEndpoints)
         }
     }
@@ -136,14 +117,6 @@ private fun SerializableEndpointConfig.getOverriddenProperties() = listOfNotNull
 
 private fun filterEndpoints(
     filter: String,
-    endpoints: List<State.EndpointConfigItem>,
-): List<State.EndpointConfig> {
-    val visible = FuzzyFilter
-        .filter(endpoints, filter) { it.name }
-        .map { it.withDisplay(true) }
-    val visibleEndpoints = visible.map { it.key }.toSet()
-    val hidden = endpoints
-        .filter { it.key !in visibleEndpoints }
-        .map { it.withDisplay(false) }
-    return visible + hidden
-}
+    endpoints: List<State.EndpointConfig>,
+): List<State.EndpointConfig> = FuzzyFilter
+    .filter(endpoints, filter) { it.name }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
@@ -5,6 +5,8 @@ import com.apadmi.mockzilla.lib.models.EndpointConfiguration
 import com.apadmi.mockzilla.management.MockzillaManagement
 import com.apadmi.mockzilla.ui.engine.device.Device
 import com.apadmi.mockzilla.ui.engine.events.EventBus
+import com.apadmi.mockzilla.ui.engine.filter.FuzzyFilter
+import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.EndpointsViewModel.State
 import com.apadmi.mockzilla.ui.viewmodel.ViewModel
 
 import kotlinx.coroutines.CoroutineScope
@@ -32,9 +34,20 @@ class EndpointsViewModel(
 
     private suspend fun reloadData() {
         state.value = endpointsService.fetchAllEndpointConfigs(device).fold(
-            onSuccess = {
+            onSuccess = { list ->
                 val currentState = state.value as? State.EndpointsList
-                State.EndpointsList(it.toConfig(), currentState?.filter ?: "")
+                val filter = currentState?.filter ?: ""
+                State.EndpointsList(
+                    allEndpoints = list.map {
+                        State.EndpointConfigItem(
+                            key = it.key,
+                            name = it.name,
+                            fail = it.shouldFail == true,
+                            overriddenProperties = it.getOverriddenProperties()
+                        )
+                    },
+                    filter
+                )
             },
             onFailure = {
                 eventBus.send(EventBus.Event.GenericError)
@@ -43,32 +56,13 @@ class EndpointsViewModel(
         )
     }
 
-    private fun List<SerializableEndpointConfig>.toConfig(): List<State.EndpointConfig> {
-        val currentState = state.value as? State.EndpointsList
-
-        return map {
-            State.EndpointConfig(
-                key = it.key,
-                name = it.name,
-                fail = it.shouldFail == true,
-                overriddenProperties = it.getOverriddenProperties(),
-                display = filter(currentState?.filter ?: "", it.name)
-            )
-        }
-    }
-
     fun onFilterChanged(value: String) {
         val currentState = state.value as? State.EndpointsList ?: return
 
         state.value = currentState.copy(
-            endpoints = currentState.endpoints.map {
-                it.copy(display = filter(value, it.name))
-            },
             filter = value
         )
     }
-
-    private fun filter(value: String, name: String) = name.lowercase().contains(value.lowercase())
 
     sealed class State {
         data object Loading : State()
@@ -89,13 +83,36 @@ class EndpointsViewModel(
         )
 
         /**
-         * @property endpoints
+         * @property key
+         * @property name
+         * @property fail
+         * @property overriddenProperties
+         */
+        data class EndpointConfigItem(
+            val key: EndpointConfiguration.Key,
+            val name: String,
+            val fail: Boolean,
+            val overriddenProperties: List<EndpointProperties>,
+        ) {
+            fun withDisplay(display: Boolean): EndpointConfig = EndpointConfig(
+                key = key,
+                name = name,
+                fail = fail,
+                overriddenProperties = overriddenProperties,
+                display = display
+            )
+        }
+
+        /**
+         * @property allEndpoints
          * @property filter
          */
         data class EndpointsList(
-            val endpoints: List<EndpointConfig>,
+            private val allEndpoints: List<EndpointConfigItem>,
             val filter: String,
-        ) : State()
+        ) : State() {
+            val endpoints: List<EndpointConfig> = filterEndpoints(filter, allEndpoints)
+        }
     }
 }
 
@@ -116,3 +133,17 @@ private fun SerializableEndpointConfig.getOverriddenProperties() = listOfNotNull
     EndpointProperties.Status.takeIf { defaultStatus != null || appliedPresetOverride?.response?.statusCode != null },
     EndpointProperties.Headers.takeIf { defaultHeaders != null || appliedPresetOverride?.response?.headers != null }
 )
+
+private fun filterEndpoints(
+    filter: String,
+    endpoints: List<State.EndpointConfigItem>,
+): List<State.EndpointConfig> {
+    val visible = FuzzyFilter
+        .filter(endpoints, filter) { it.name }
+        .map { it.withDisplay(true) }
+    val visibleEndpoints = visible.map { it.key }.toSet()
+    val hidden = endpoints
+        .filter { it.key !in visibleEndpoints }
+        .map { it.withDisplay(false) }
+    return visible + hidden
+}

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -291,25 +291,23 @@ private fun FilterTextField(
 private fun EndpointsWidgetPreview() = PreviewSurface {
     EndpointsWidgetContent(
         state = EndpointsViewModel.State.EndpointsList(
-            endpoints = listOf(
-                EndpointsViewModel.State.EndpointConfig(
+            allEndpoints = listOf(
+                EndpointsViewModel.State.EndpointConfigItem(
                     key = Key("1"),
                     name = "FooBar",
                     fail = false,
                     overriddenProperties = listOf(
                         EndpointProperties.Delay,
                         EndpointProperties.Body
-                    ),
-                    display = true
+                    )
                 ),
-                EndpointsViewModel.State.EndpointConfig(
+                EndpointsViewModel.State.EndpointConfigItem(
                     key = Key("2"),
                     name = "Foo",
                     fail = true,
-                    overriddenProperties = emptyList(),
-                    display = true
+                    overriddenProperties = emptyList()
                 ),
-                EndpointsViewModel.State.EndpointConfig(
+                EndpointsViewModel.State.EndpointConfigItem(
                     key = Key("3"),
                     name = "FooBuzz",
                     fail = false,
@@ -319,25 +317,22 @@ private fun EndpointsWidgetPreview() = PreviewSurface {
                         EndpointProperties.Delay,
                         EndpointProperties.Body,
                         EndpointProperties.Headers
-                    ),
-                    display = true
+                    )
                 ),
-                EndpointsViewModel.State.EndpointConfig(
+                EndpointsViewModel.State.EndpointConfigItem(
                     key = Key("4"),
                     name = "Foobar",
                     fail = false,
-                    overriddenProperties = emptyList(),
-                    display = true
+                    overriddenProperties = emptyList()
                 ),
-                EndpointsViewModel.State.EndpointConfig(
+                EndpointsViewModel.State.EndpointConfigItem(
                     key = Key("5"),
                     name = "Foobuzz",
                     fail = true,
                     overriddenProperties = listOf(
                         EndpointProperties.Delay,
                         EndpointProperties.Body
-                    ),
-                    display = true
+                    )
                 )
             ),
             filter = "Foo",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -88,8 +88,8 @@ private fun EndpointsList(
 
     Text(
         text = strings.widgets.endpoints.numberOfEndpointsShown(
-            state.endpoints.filter { it.display }.size,
-            state.endpoints.size
+            state.endpoints.size,
+            state.allEndpoints.size
         ),
         color = MaterialTheme.colorScheme.onBackground,
         style = MaterialTheme.typography.labelSmall
@@ -97,7 +97,7 @@ private fun EndpointsList(
 
     Spacer(modifier = Modifier.height(8.dp))
 
-    state.endpoints.filter { it.display }.forEach { endpoint ->
+    state.endpoints.forEach { endpoint ->
         EndpointCard(
             endpoint = endpoint,
             onEndpointClicked = onEndpointClicked
@@ -292,7 +292,7 @@ private fun EndpointsWidgetPreview() = PreviewSurface {
     EndpointsWidgetContent(
         state = EndpointsViewModel.State.EndpointsList(
             allEndpoints = listOf(
-                EndpointsViewModel.State.EndpointConfigItem(
+                EndpointsViewModel.State.EndpointConfig(
                     key = Key("1"),
                     name = "FooBar",
                     fail = false,
@@ -301,13 +301,13 @@ private fun EndpointsWidgetPreview() = PreviewSurface {
                         EndpointProperties.Body
                     )
                 ),
-                EndpointsViewModel.State.EndpointConfigItem(
+                EndpointsViewModel.State.EndpointConfig(
                     key = Key("2"),
                     name = "Foo",
                     fail = true,
                     overriddenProperties = emptyList()
                 ),
-                EndpointsViewModel.State.EndpointConfigItem(
+                EndpointsViewModel.State.EndpointConfig(
                     key = Key("3"),
                     name = "FooBuzz",
                     fail = false,
@@ -319,13 +319,13 @@ private fun EndpointsWidgetPreview() = PreviewSurface {
                         EndpointProperties.Headers
                     )
                 ),
-                EndpointsViewModel.State.EndpointConfigItem(
+                EndpointsViewModel.State.EndpointConfig(
                     key = Key("4"),
                     name = "Foobar",
                     fail = false,
                     overriddenProperties = emptyList()
                 ),
-                EndpointsViewModel.State.EndpointConfigItem(
+                EndpointsViewModel.State.EndpointConfig(
                     key = Key("5"),
                     name = "Foobuzz",
                     fail = true,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/endpoints/details/EndpointsViewModelTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/endpoints/details/EndpointsViewModelTests.kt
@@ -25,19 +25,19 @@ import kotlinx.coroutines.yield
 class EndpointsViewModelTests : CoroutineTest() {
     private val defaultEndpointList = State.EndpointsList(
         listOf(
-            State.EndpointConfigItem(
+            State.EndpointConfig(
                 key = EndpointConfiguration.Key("Key1"),
                 name = "Name1",
                 fail = false,
                 overriddenProperties = emptyList()
             ),
-            State.EndpointConfigItem(
+            State.EndpointConfig(
                 key = EndpointConfiguration.Key("Key2"),
                 name = "Name2",
                 fail = true,
                 overriddenProperties = emptyList()
             ),
-            State.EndpointConfigItem(
+            State.EndpointConfig(
                 key = EndpointConfiguration.Key("Key3"),
                 name = "Name3",
                 fail = true,
@@ -128,9 +128,9 @@ class EndpointsViewModelTests : CoroutineTest() {
             /* Verify */
             assertEquals(
                 listOf(
-                    defaultEndpointList.endpoints[0].copy(display = true),
-                    defaultEndpointList.endpoints[1].copy(display = true),
-                    defaultEndpointList.endpoints[2].copy(display = true),
+                    defaultEndpointList.endpoints[0],
+                    defaultEndpointList.endpoints[1],
+                    defaultEndpointList.endpoints[2],
                 ),
                 (result1 as State.EndpointsList).endpoints
             )
@@ -141,9 +141,9 @@ class EndpointsViewModelTests : CoroutineTest() {
 
             assertEquals(
                 listOf(
-                    defaultEndpointList.endpoints[1].copy(display = true),
-                    defaultEndpointList.endpoints[0].copy(display = true),
-                    defaultEndpointList.endpoints[2].copy(display = true),
+                    defaultEndpointList.endpoints[1],
+                    defaultEndpointList.endpoints[0],
+                    defaultEndpointList.endpoints[2],
                 ),
                 (result2 as State.EndpointsList).endpoints
             )
@@ -153,11 +153,7 @@ class EndpointsViewModelTests : CoroutineTest() {
             )
 
             assertEquals(
-                listOf(
-                    defaultEndpointList.endpoints[0].copy(display = false),
-                    defaultEndpointList.endpoints[1].copy(display = false),
-                    defaultEndpointList.endpoints[2].copy(display = false),
-                ),
+                listOf(),
                 (result3 as State.EndpointsList).endpoints
             )
             assertEquals(
@@ -169,9 +165,7 @@ class EndpointsViewModelTests : CoroutineTest() {
 
             assertEquals(
                 listOf(
-                    defaultEndpointList.endpoints[1].copy(display = true),
-                    defaultEndpointList.endpoints[0].copy(display = false),
-                    defaultEndpointList.endpoints[2].copy(display = false),
+                    defaultEndpointList.endpoints[1],
                 ),
                 (result5 as State.EndpointsList).endpoints
             )

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/endpoints/details/EndpointsViewModelTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/endpoints/details/EndpointsViewModelTests.kt
@@ -25,26 +25,23 @@ import kotlinx.coroutines.yield
 class EndpointsViewModelTests : CoroutineTest() {
     private val defaultEndpointList = State.EndpointsList(
         listOf(
-            State.EndpointConfig(
+            State.EndpointConfigItem(
                 key = EndpointConfiguration.Key("Key1"),
                 name = "Name1",
                 fail = false,
-                overriddenProperties = emptyList(),
-                display = true
+                overriddenProperties = emptyList()
             ),
-            State.EndpointConfig(
+            State.EndpointConfigItem(
                 key = EndpointConfiguration.Key("Key2"),
                 name = "Name2",
                 fail = true,
-                overriddenProperties = emptyList(),
-                display = true
+                overriddenProperties = emptyList()
             ),
-            State.EndpointConfig(
+            State.EndpointConfigItem(
                 key = EndpointConfiguration.Key("Key3"),
                 name = "Name3",
                 fail = true,
-                overriddenProperties = listOf(EndpointProperties.Delay),
-                display = true
+                overriddenProperties = listOf(EndpointProperties.Delay)
             )
         ),
         filter = ""
@@ -119,44 +116,69 @@ class EndpointsViewModelTests : CoroutineTest() {
             sut.onFilterChanged("Name2")
             val result2 = awaitItem()
 
-            sut.onFilterChanged("Name4")
+            sut.onFilterChanged("asdf")
             val result3 = awaitItem()
 
             sut.onFilterChanged("")
             val result4 = awaitItem()
 
+            sut.onFilterChanged("me2")
+            val result5 = awaitItem()
+
             /* Verify */
             assertEquals(
-                defaultEndpointList.copy(
-                    endpoints = defaultEndpointList.endpoints.mapIndexed { index, value ->
-                        value.copy(display = index == 0)
-                    },
-                    filter = "Name1"
+                listOf(
+                    defaultEndpointList.endpoints[0].copy(display = true),
+                    defaultEndpointList.endpoints[1].copy(display = true),
+                    defaultEndpointList.endpoints[2].copy(display = true),
                 ),
-                (result1 as State.EndpointsList)
+                (result1 as State.EndpointsList).endpoints
+            )
+            assertEquals(
+                "Name1",
+                result1.filter
             )
 
             assertEquals(
-                defaultEndpointList.copy(
-                    endpoints = defaultEndpointList.endpoints.mapIndexed { index, value ->
-                        value.copy(display = index == 1)
-                    },
-                    filter = "Name2"
+                listOf(
+                    defaultEndpointList.endpoints[1].copy(display = true),
+                    defaultEndpointList.endpoints[0].copy(display = true),
+                    defaultEndpointList.endpoints[2].copy(display = true),
                 ),
-                (result2 as State.EndpointsList)
+                (result2 as State.EndpointsList).endpoints
+            )
+            assertEquals(
+                "Name2",
+                result2.filter
             )
 
             assertEquals(
-                defaultEndpointList.copy(
-                    endpoints = defaultEndpointList.endpoints.map {
-                        it.copy(display = false)
-                    },
-                    filter = "Name4"
+                listOf(
+                    defaultEndpointList.endpoints[0].copy(display = false),
+                    defaultEndpointList.endpoints[1].copy(display = false),
+                    defaultEndpointList.endpoints[2].copy(display = false),
                 ),
-                (result3 as State.EndpointsList)
+                (result3 as State.EndpointsList).endpoints
+            )
+            assertEquals(
+                "asdf",
+                result3.filter
             )
 
             assertEquals(defaultEndpointList, (result4 as State.EndpointsList))
+
+            assertEquals(
+                listOf(
+                    defaultEndpointList.endpoints[1].copy(display = true),
+                    defaultEndpointList.endpoints[0].copy(display = false),
+                    defaultEndpointList.endpoints[2].copy(display = false),
+                ),
+                (result5 as State.EndpointsList).endpoints
+            )
+            assertEquals(
+                "me2",
+                result5.filter
+            )
         }
     }
 }


### PR DESCRIPTION
This adds a modest tolerance for making typos when searching with the endpoints filter. Exact matches are sorted first, up to 2 edits away from a match can be included after exact matches depending on the length of the filter string (as very short filter strings trivially match nearly anything with edits of a similar number to the length of the string).