### PR TITLE
Sync release-please manifest + add Flutter web component

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,13 +1,13 @@
 {
-  "FlutterMockzilla": "1.0.0",
   "mockzilla": "3.0.0",
   "mockzilla-common": "3.0.0",
   "mockzilla-management": "3.0.0",
   "FlutterMockzilla/mockzilla_ui_mobile": "1.0.0",
-  "FlutterMockzilla/mockzilla": "1.3.0",
-  "FlutterMockzilla/mockzilla_android": "1.2.1",
-  "FlutterMockzilla/mockzilla_ios": "1.2.1",
+  "FlutterMockzilla/mockzilla": "2.0.0",
+  "FlutterMockzilla/mockzilla_android": "2.0.0",
+  "FlutterMockzilla/mockzilla_ios": "2.0.0",
   "FlutterMockzilla/mockzilla_platform_interface": "2.0.0",
+  "FlutterMockzilla/mockzilla_web": "0.0.3",
   "mockzilla-management-ui/mockzilla-mobile-ui": "1.0.0",
   "mockzilla-management-ui/mockzilla-desktop": "2.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -36,6 +36,11 @@
       "release-type": "dart",
       "always-update": true
     },
+    "FlutterMockzilla/mockzilla_web": {
+      "component": "flutter_mockzilla_web",
+      "release-type": "dart",
+      "always-update": true
+    },
     "mockzilla-management-ui/mockzilla-desktop": {
       "component": "mockzilla-desktop",
       "extra-files": ["build.gradle.kts"]


### PR DESCRIPTION
- Adds the `mockzilla_web` Flutter package to the release-please configuration.
- Syncs the release-please manifest with the last published package versions.