### PR TITLE
feat(#557): fix port conflict issue on Android

### DIFF
--- a/mockzilla/src/allButWebMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.allButWeb.kt
+++ b/mockzilla/src/allButWebMain/kotlin/com/apadmi/mockzilla/lib/internal/Server.allButWeb.kt
@@ -14,6 +14,7 @@ import com.apadmi.mockzilla.lib.models.MockzillaRuntimeParams
 import com.apadmi.mockzilla.lib.models.PortConflictException
 
 import co.touchlab.kermit.Logger
+import com.apadmi.mockzilla.lib.internal.utils.runHandlingPortConflict
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.*
@@ -25,6 +26,9 @@ import io.ktor.server.response.respondText
 import io.ktor.server.routing.IgnoreTrailingSlash
 import io.ktor.server.routing.RoutingCall
 import io.ktor.server.routing.RoutingContext
+import io.ktor.util.Platform
+import io.ktor.util.PlatformUtils
+import io.ktor.util.platform
 import io.ktor.utils.io.CancellationException
 
 import kotlinx.coroutines.*
@@ -81,21 +85,10 @@ private fun Application.setupServerEnvironment(job: CompletableJob, di: Dependen
     }
     configureEndpoints(job, di)
 }
-
-private fun EmbeddedServer<*, *>.startWithErrorHandling(di: DependencyInjector) = try {
-    start(wait = false)
-} catch (e: Exception) {
-    if (e.isSomeMatchInChain { it is AddressAlreadyInUseException }) {
-        PortConflictException(di.config.port, e).also { exception ->
-            di.logger.e(exception.message, exception)
-            throw exception
-        }
-    } else {
-        throw e
-    }
-}
-
-internal actual suspend fun startServer(port: Int, di: DependencyInjector): MockzillaRuntimeParams {
+internal actual suspend fun startServer(
+    port: Int,
+    di: DependencyInjector
+): MockzillaRuntimeParams = runHandlingPortConflict(port) {
     stopServer()
 
     val job = SupervisorJob().also { job = it }
@@ -113,7 +106,7 @@ internal actual suspend fun startServer(port: Int, di: DependencyInjector): Mock
     }).apply {
         application.setupServerEnvironment(job = job, di = di)
         server = this.application.engine
-        startWithErrorHandling(di)
+        start(wait = false)
     }
 
     val actualPort = serverEngine.application.engine.resolvedConnectors()
@@ -123,7 +116,7 @@ internal actual suspend fun startServer(port: Int, di: DependencyInjector): Mock
 
     startNetworkDiscoveryBroadcastIfNeeded(job, di, actualPort)
 
-    return MockzillaRuntimeParams(
+    MockzillaRuntimeParams(
         config = di.config,
         ip = "127.0.0.1",
         mockBaseUrl = "http://127.0.0.1:$actualPort/local-mock",

--- a/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/AndroidMockzilla.kt
+++ b/mockzilla/src/androidMain/kotlin/com/apadmi/mockzilla/lib/AndroidMockzilla.kt
@@ -5,10 +5,13 @@ import com.apadmi.mockzilla.lib.internal.discovery.ZeroConfDiscoveryServiceImpl
 import com.apadmi.mockzilla.lib.internal.stopServer
 import com.apadmi.mockzilla.lib.internal.utils.FileIo
 import com.apadmi.mockzilla.lib.internal.utils.extractMetaData
+import com.apadmi.mockzilla.lib.internal.utils.runHandlingPortConflict
 
 import com.apadmi.mockzilla.lib.models.MockzillaConfig
 import com.apadmi.mockzilla.lib.models.MockzillaRuntimeParams
 import kotlinx.coroutines.runBlocking
+import java.net.ServerSocket
+import kotlin.use
 
 /**
  * Starts the Mockzilla server,
@@ -18,6 +21,18 @@ import kotlinx.coroutines.runBlocking
  * @return runtimeParams Configuration of the mockzilla runtime environment
  */
 fun startMockzilla(config: MockzillaConfig, context: Context): MockzillaRuntimeParams = runBlocking {
+    // On Android we must check if the port is available before launching Mockzilla since the
+    // Ktor exception cannot be correctly caught and crashes the app regardless off error handling
+    // https://github.com/Apadmi-Engineering/Mockzilla/issues/557
+    runHandlingPortConflict(config.port) {
+        ServerSocket(config.port).use { socket ->
+            // If we did manage to make the Socket make sure
+            // we don't block Mockzilla from using it immediately
+            // after we're done
+            socket.reuseAddress = true
+        }
+    }
+
     startMockzilla(
         config = config,
         metaData = context.extractMetaData(),

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/SocketUtils.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/utils/SocketUtils.kt
@@ -1,0 +1,16 @@
+package com.apadmi.mockzilla.lib.internal.utils
+
+import com.apadmi.mockzilla.lib.internal.di.DependencyInjector
+import com.apadmi.mockzilla.lib.models.PortConflictException
+
+internal suspend fun <T> runHandlingPortConflict(port: Int, block: suspend () -> T): T {
+    try {
+        return block()
+    } catch (e: Exception) {
+        if (e.isSomeMatchInChain { it is AddressAlreadyInUseException }) {
+            throw PortConflictException(port, e)
+        } else {
+            throw e
+        }
+    }
+}


### PR DESCRIPTION
This is a quick win on Android, it's still on issue on iOS but it's harder to fix there since it takes longer for the server to shut down so when re-running the app the new instance can re-bind to the same port, adding this same change on iOS would break that and be really annoying