### PR TITLE
feat(monitor-logs): implement real-time monitor logs widget and log detail panel

### DIFF
--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/DesktopAppRoot.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/DesktopAppRoot.kt
@@ -76,6 +76,10 @@ fun DesktopApp(
                 openWidgets = openWidgets.minus(createPresetWidgetId)
                 openWidgets = openWidgets.plus(editPresetWidgetId)
             },
+            onCloseLogDetail = {
+                logDetail = null
+                openWidgets = openWidgets.minus(logDetailsWidgetId)
+            },
         )
 
         WidgetScaffold(
@@ -193,8 +197,8 @@ private fun rightPanelWidgets(
     logDetail: LogEvent?,
     strings: Strings,
     onCreatePreset: (EndpointConfiguration.Key) -> Unit,
-    onEditPreset: (EndpointConfiguration.Key) -> Unit
-
+    onEditPreset: (EndpointConfiguration.Key) -> Unit,
+    onCloseLogDetail: () -> Unit,
 ) = (state as? AppRootViewModel.State.Connected)?.let { connectedState ->
     buildList {
         add(
@@ -217,7 +221,7 @@ private fun rightPanelWidgets(
             Widget(
                 id = logDetailsWidgetId, title = strings.widgets.logDetails.title
             ) {
-                MonitorLogDetailsWidget(logDetail)
+                MonitorLogDetailsWidget(logDetail = logDetail, onClose = onCloseLogDetail)
             }
         )
     }

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/Dividers.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/Dividers.kt
@@ -38,6 +38,7 @@ internal fun HorizontalDraggableDivider(
 @Composable
 internal fun VerticalDraggableDivider(
     onDrag: (Float) -> Unit,
+    onDragStarted: () -> Unit = {},
     onDragStopped: () -> Unit,
 ) {
     Box(
@@ -51,6 +52,7 @@ internal fun VerticalDraggableDivider(
                     onDrag(dragAmount)
                 },
                 orientation = Orientation.Vertical,
+                onDragStarted = { _ -> onDragStarted() },
                 onDragStopped = { onDragStopped() },
             )
     )

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
@@ -18,8 +18,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.min
-import com.apadmi.mockzilla.ui.ui.common.scaffold.HorizontalTab
-import com.apadmi.mockzilla.ui.ui.common.scaffold.HorizontalTabList
 import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTab
 import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTabList
 
@@ -62,8 +60,6 @@ fun WidgetScaffold(
     var leftPanelSettledWidth by remember { mutableStateOf(230.dp) }
     var rightPanelWidth by remember { mutableStateOf(280.dp) }
     var rightPanelSettledWidth by remember { mutableStateOf(280.dp) }
-    var bottomPanelHeight by remember { mutableStateOf(140.dp) }
-    var bottomPanelSettledHeight by remember { mutableStateOf(140.dp) }
 
     // Both of the horizontal panels must collectively not be so large that the center panel
     // runs out of space. We can enforce this by hoisting the width of each panel and preventing
@@ -85,12 +81,9 @@ fun WidgetScaffold(
             max(0.dp, width)
         }
     }
-    val bottomPanelHeightRestriction = { height: Dp -> max(0.dp, height) }
-
-    val colorScheme = MaterialTheme.colorScheme
     Box(
         modifier = modifier
-            .background(colorScheme.background)
+            .background(MaterialTheme.colorScheme.background)
             .onSizeChanged { size ->
                 totalWidth = with(density) { size.width.toDp() }
             },
@@ -137,78 +130,15 @@ fun WidgetScaffold(
                     onSelected = onSelected
                 )
             }
-            BottomPanel(
-                content = bottom,
-                openWidgets = openWidgets,
-                height = bottomPanelHeight,
-                settledHeight = bottomPanelSettledHeight,
-                onHeightChange = {
-                    bottomPanelHeight = it
-                    bottomPanelSettledHeight = bottomPanelHeightRestriction(it)
-                },
-                onDragStopped = {
-                    bottomPanelHeight = bottomPanelSettledHeight
-                },
-                onSelected = onSelected
-            )
+            BottomPanel(content = bottom)
         }
     }
 }
 
-@Suppress(
-    "TOO_LONG_FUNCTION",
-    "LOCAL_VARIABLE_EARLY_DECLARATION",
-    "MAGIC_NUMBER"
-)
 @Composable
-private fun BottomPanel(
-    content: List<Widget>,
-    openWidgets: Set<String>,
-    height: Dp,
-    settledHeight: Dp,
-    defaultHeight: Dp = 200.dp,
-    onDragStopped: () -> Unit,
-    onHeightChange: (Dp) -> Unit,
-    onSelected: (String) -> Unit,
-) {
-    val density = LocalDensity.current
-    val selectedWidget = remember(openWidgets) {
-        content.indices.firstOrNull { openWidgets.contains(content[it].id) }
-    }
-
+private fun BottomPanel(content: List<Widget>) {
     Column(modifier = Modifier.fillMaxWidth()) {
-        selectedWidget?.let {
-            VerticalDraggableDivider(
-                onDrag = { offset ->
-                    with(density) {
-                        onHeightChange(height - offset.toDp())
-                    }
-                },
-                onDragStopped = onDragStopped
-            )
-        }
-
-        Surface(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .fillMaxWidth()
-                .height(selectedWidget?.let { settledHeight } ?: 0.dp)
-        ) {
-            selectedWidget?.let {
-                content.getOrNull(it)?.ui?.invoke()
-            }
-        }
-
-        HorizontalTabList(
-            tabs = content.map { widget -> HorizontalTab(title = widget.title) },
-            selected = selectedWidget,
-            onSelect = { widget ->
-                onSelected(content[widget].id)
-                if (height < 20.dp) {
-                    onHeightChange(defaultHeight)
-                }
-            }
-        )
+        content.forEach { widget -> widget.ui() }
     }
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/build.gradle.kts
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/build.gradle.kts
@@ -68,6 +68,9 @@ kotlin {
             /* Coroutines */
             implementation(libs.kotlinx.coroutines.core)
 
+            /* Date / Time */
+            implementation(libs.kotlinx.datetime)
+
             /* JSON */
             implementation(libs.kotlinx.serialization.json)
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
@@ -82,6 +82,7 @@ val EnStrings = Strings(
         logs = Strings.Widgets.Logs(
             title = "Logs",
             clearAll = "Clear all",
+            openInPanel = "Open in panel →",
         ),
         logDetails = Strings.Widgets.LogDetails(
             title = "Log Detail",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
@@ -83,6 +83,8 @@ val EnStrings = Strings(
             title = "Logs",
             clearAll = "Clear all",
             openInPanel = "Open in panel →",
+            streaming = "STREAMING",
+            clickToInspect = "·  CLICK ROW TO INSPECT",
         ),
         logDetails = Strings.Widgets.LogDetails(
             title = "Log Detail",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
@@ -96,7 +96,8 @@ val EnStrings = Strings(
             responseHeaders = "Response headers",
             responseBody = "Response body",
             noHeaders = "None",
-            noBody = "Empty"
+            noBody = "Empty",
+            emptyBody = "(none)"
         ),
         endpoints = Strings.Widgets.Endpoints(
             filterPlaceholder = "Filter endpoints...",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
@@ -79,10 +79,12 @@ data class Strings(
         /**
          * @property title
          * @property clearAll
+         * @property openInPanel
          */
         data class Logs(
             val title: String,
             val clearAll: String,
+            val openInPanel: String,
         )
 
         /**

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
@@ -100,6 +100,7 @@ data class Strings(
          * @property responseBody
          * @property noHeaders
          * @property noBody
+         * @property emptyBody
          */
         data class LogDetails(
             val title: String,
@@ -113,7 +114,8 @@ data class Strings(
             val responseHeaders: String,
             val responseBody: String,
             val noHeaders: String,
-            val noBody: String
+            val noBody: String,
+            val emptyBody: String,
         )
 
         /**

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
@@ -80,11 +80,15 @@ data class Strings(
          * @property title
          * @property clearAll
          * @property openInPanel
+         * @property streaming
+         * @property clickToInspect
          */
         data class Logs(
             val title: String,
             val clearAll: String,
             val openInPanel: String,
+            val streaming: String,
+            val clickToInspect: String,
         )
 
         /**

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/StatusChip.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/StatusChip.kt
@@ -1,12 +1,10 @@
 package com.apadmi.mockzilla.ui.ui.common.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,7 +15,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 
-import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
+import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
 import com.apadmi.mockzilla.ui.ui.common.theme.success
 import com.apadmi.mockzilla.ui.ui.common.theme.warning
 
@@ -29,24 +27,14 @@ enum class ChipTone {
 
 /**
  * @property border
- * @property background
  * @property text
+ * @property background
  */
 private data class ChipColors(
     val border: Color,
-    val background: Color,
-    val text: Color
+    val text: Color,
+    val background: Color
 )
-
-@Composable
-private fun ColorScheme.chipColors(tone: ChipTone) = when (tone) {
-    ChipTone.Ok -> ChipColors(success.primary, success.container, success.primary)
-    ChipTone.Warn -> ChipColors(warning.primary, warning.container, warning.primary)
-    ChipTone.Err -> ChipColors(error, errorContainer, error)
-    ChipTone.Accent -> ChipColors(primary, primaryContainer, primary)
-    ChipTone.Info -> ChipColors(tertiary, tertiaryContainer, tertiary)
-    ChipTone.Neutral -> ChipColors(outline, surfaceVariant, onSurfaceMuted)
-}
 
 @Suppress("MAGIC_NUMBER")
 @Composable
@@ -55,15 +43,14 @@ fun StatusChip(
     tone: ChipTone = ChipTone.Neutral,
     modifier: Modifier = Modifier,
 ) {
-    val colors = MaterialTheme.colorScheme.chipColors(tone)
-    val monoFont = com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily.current
+    val colors = chipColors(tone)
+    val monoFont = LocalMonoFontFamily.current
 
     Text(
         text = label,
         modifier = modifier
-            .background(color = colors.background, shape = RoundedCornerShape(10.dp))
-            .border(width = 1.dp, color = colors.border, shape = RoundedCornerShape(10.dp))
-            .padding(horizontal = 6.dp, vertical = 2.dp),
+            .border(width = 1.dp, color = colors.border, shape = RoundedCornerShape(3.dp))
+            .padding(horizontal = 4.dp, vertical = 1.dp),
         style = MaterialTheme.typography.labelSmall.copy(
             fontFamily = monoFont,
             fontSize = 10.sp,
@@ -72,6 +59,41 @@ fun StatusChip(
         ),
         color = colors.text,
     )
+}
+
+@Composable
+private fun chipColors(tone: ChipTone): ChipColors {
+    val cs = MaterialTheme.colorScheme
+    return when (tone) {
+        ChipTone.Ok -> {
+            val color = cs.success.primary
+            ChipColors(border = color, text = color, background = color.copy(alpha = 0.14f))
+        }
+        ChipTone.Warn -> {
+            val color = cs.warning.primary
+            ChipColors(border = color, text = color, background = color.copy(alpha = 0.14f))
+        }
+        ChipTone.Err -> ChipColors(
+            border = cs.error,
+            text = cs.error,
+            background = cs.errorContainer,
+        )
+        ChipTone.Accent -> ChipColors(
+            border = cs.primary,
+            text = cs.primary,
+            background = cs.primaryContainer,
+        )
+        ChipTone.Info -> ChipColors(
+            border = cs.tertiary,
+            text = cs.tertiary,
+            background = cs.tertiaryContainer,
+        )
+        ChipTone.Neutral -> ChipColors(
+            border = cs.outline,
+            text = cs.onSurfaceVariant,
+            background = cs.surfaceVariant,
+        )
+    }
 }
 
 @Preview

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Color.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Color.kt
@@ -36,6 +36,7 @@ val darkError = Color(0xFFF87171)
 val darkErrorContainer = darkError.copy(alpha = 0.14f)
 val darkTertiary = Color(0xFF38BDF8)
 val darkTertiaryContainer = darkTertiary.copy(alpha = 0.14f)
+val darkJsonKey = Color(0xFFA78BFA)
 
 // ── Light theme ───────────────────────────────────────────────────────────────
 val lightBackground = Color(0xFFF8FAFC)
@@ -66,6 +67,7 @@ val lightError = Color(0xFFDC2626)
 val lightErrorContainer = lightError.copy(alpha = 0.14f)
 val lightTertiary = Color(0xFF0284C7)
 val lightTertiaryContainer = lightTertiary.copy(alpha = 0.14f)
+val lightJsonKey = Color(0xFF7C3AED)
 
 // ── HTTP method colours (shared; themed via ColorScheme extensions) ──────────
 val darkMethodGet = Color(0xFF5ECDE8)

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Theme.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Theme.kt
@@ -128,6 +128,10 @@ val ColorScheme.warning: StateColors
     }
 
 @get:Composable
+val ColorScheme.jsonKey: Color
+    get() = if (LocalForceDarkMode.current || isSystemInDarkTheme()) darkJsonKey else lightJsonKey
+
+@get:Composable
 val ColorScheme.methodGet: Color
     get() = if (LocalForceDarkMode.current || isSystemInDarkTheme()) darkMethodGet else lightMethodGet
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/MonitorLogsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/MonitorLogsWidget.kt
@@ -1,16 +1,32 @@
 package com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +38,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 
 import com.apadmi.mockzilla.lib.internal.models.LogEvent
@@ -33,25 +55,32 @@ import com.apadmi.mockzilla.ui.i18n.Strings
 import com.apadmi.mockzilla.ui.ui.common.components.ChipTone
 import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
 import com.apadmi.mockzilla.ui.ui.common.components.StatusChip
-import com.apadmi.mockzilla.ui.ui.common.components.buttons.BaseButton
-import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonSize
-import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonVariant
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
-import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceFaint
-import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
+import com.apadmi.mockzilla.ui.ui.common.theme.success
 import com.apadmi.mockzilla.ui.ui.common.theme.warning
-import com.apadmi.mockzilla.ui.ui.common.utils.methodColor
 
 import io.ktor.http.HttpStatusCode
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
+import kotlin.time.Instant
+
+/** Extracts `HH:mm:ss.mmm` from epoch millis (UTC). */
+private fun Long.formatTimestamp(): String =
+    Instant.fromEpochMilliseconds(this)
+        .toString()
+        .substringAfter("T")
+        .substringBeforeLast("Z")
 
 @Suppress("MAGIC_NUMBER")
-private fun HttpStatusCode.chipTone(): ChipTone = when (this.value) {
-    in 200..299 -> ChipTone.Ok
-    in 400..499 -> ChipTone.Warn
-    in 500..599 -> ChipTone.Err
-    else -> ChipTone.Neutral
+@Composable
+private fun HttpStatusCode.statusColor(isIntendedFailure: Boolean): Color {
+    val cs = MaterialTheme.colorScheme
+    return when {
+        value in 200..299 -> cs.success.primary
+        isIntendedFailure -> cs.warning.primary
+        value >= 400 -> cs.error
+        else -> cs.onSurface.copy(alpha = 0.5f)
+    }
 }
 
 @Composable
@@ -69,70 +98,177 @@ fun MonitorLogsWidget(
     )
 }
 
+@Suppress("MAGIC_NUMBER")
 @Composable
 fun MonitorLogsWidgetContent(
     state: MonitorLogsViewModel.State.DisplayLogs,
     onClearAll: () -> Unit,
     onViewDetail: (LogEvent) -> Unit,
+    onOpenPanel: () -> Unit = {},
     strings: Strings = LocalStrings.current,
 ) {
-    val colorScheme = MaterialTheme.colorScheme
-    Column(modifier = Modifier.background(colorScheme.background)) {
+    val monoFont = LocalMonoFontFamily.current
+    val cs = MaterialTheme.colorScheme
+    val panelBg = if (isSystemInDarkTheme()) cs.background else cs.surface
+    val streamingColor = cs.success.primary
+    val dimColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+    val faintColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+    val entryList = state.entries.toList()
+    val titleStyle = MaterialTheme.typography.labelSmall.copy(
+        fontFamily = monoFont,
+        fontWeight = FontWeight.SemiBold,
+    )
+    val logsTitle = strings.widgets.logs.title.uppercase()
+
+    var isExpanded by remember { mutableStateOf(false) }
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (isExpanded) 90f else 0f,
+        animationSpec = tween(durationMillis = 250),
+        label = "chevronRotation",
+    )
+
+    Column(modifier = Modifier.background(panelBg)) {
+        HorizontalDivider(color = MaterialTheme.colorScheme.outline)
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(panelBg)
+                .clickable { isExpanded = !isExpanded }
+                .padding(horizontal = 12.dp, vertical = 7.dp),
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp),
         ) {
-            Text(
-                text = strings.widgets.logs.title,
-                style = MaterialTheme.typography.labelSmall,
-                color = colorScheme.onSurfaceMuted,
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowRight,
+                contentDescription = null,
+                tint = faintColor,
+                modifier = Modifier.size(14.dp).rotate(chevronRotation),
             )
-            BaseButton(
-                label = strings.widgets.logs.clearAll,
-                variant = ButtonVariant.Soft,
-                size = ButtonSize.Sm,
-                onClick = onClearAll,
+            Text(
+                text = logsTitle,
+                style = titleStyle,
+                color = dimColor,
+            )
+            Canvas(modifier = Modifier.size(6.dp)) { drawCircle(color = streamingColor) }
+            Text(
+                text = "STREAMING",
+                style = MaterialTheme.typography.labelSmall.copy(fontFamily = monoFont),
+                color = streamingColor,
+            )
+            Text(
+                text = "·  CLICK ROW TO INSPECT",
+                style = MaterialTheme.typography.labelSmall.copy(fontFamily = monoFont),
+                color = faintColor,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                modifier = Modifier.clickable(onClick = onOpenPanel),
+                text = strings.widgets.logs.openInPanel,
+                style = MaterialTheme.typography.labelSmall.copy(fontFamily = monoFont),
+                color = dimColor,
             )
         }
-        MonitorLogsList(
-            entries = state.entries,
-            onViewDetail = onViewDetail,
-            modifier = Modifier.weight(1f),
-        )
+
+        AnimatedVisibility(
+            visible = isExpanded,
+            enter = expandVertically(
+                expandFrom = Alignment.Top,
+                animationSpec = tween(durationMillis = 320),
+            ) + fadeIn(animationSpec = tween(durationMillis = 220)),
+            exit = shrinkVertically(
+                shrinkTowards = Alignment.Top,
+                animationSpec = tween(durationMillis = 260),
+            ) + fadeOut(animationSpec = tween(durationMillis = 180)),
+        ) {
+            MonitorLogsList(
+                entryList = entryList,
+                panelBg = panelBg,
+                onViewDetail = onViewDetail,
+                modifier = Modifier.height(280.dp),
+            )
+        }
     }
 }
 
+@Suppress("MAGIC_NUMBER")
 @Composable
 fun LogRow(
     modifier: Modifier,
     event: LogEvent,
 ) {
-    val colorScheme = MaterialTheme.colorScheme
     val monoFont = LocalMonoFontFamily.current
+    val cs = MaterialTheme.colorScheme
+    val isSlowRequest = (event.delay ?: 0) > 1000
+    val isRealError = event.status.value >= 400 && !event.isIntendedFailure
+    val errorColor = cs.error
+    val errorBgColor = cs.errorContainer
+    val panelBg = if (isSystemInDarkTheme()) cs.background else cs.surface
+    val faintColor = cs.onSurface.copy(alpha = 0.3f)
+    val slowColor = cs.warning.primary
+
     Row(
-        modifier = modifier.padding(horizontal = 10.dp, vertical = 5.dp),
+        modifier = modifier
+            .background(if (isRealError) errorBgColor else panelBg)
+            .drawBehind {
+                if (isRealError) {
+                    drawRect(color = errorColor, size = Size(3.dp.toPx(), size.height))
+                }
+            }
+            .padding(horizontal = 12.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        StatusChip(label = event.status.value.toString(), tone = event.status.chipTone())
+        Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = event.timestamp.formatTimestamp(),
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontFamily = monoFont,
+                    fontWeight = FontWeight.Normal,
+                ),
+                color = faintColor,
+                modifier = Modifier.defaultMinSize(minWidth = 88.dp),
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = event.url,
+                style = MaterialTheme.typography.labelSmall.copy(
+                    fontFamily = monoFont,
+                    fontWeight = FontWeight.Medium,
+                ),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+            )
+            if (event.isIntendedFailure || isRealError) {
+                Spacer(modifier = Modifier.width(8.dp))
+                if (event.isIntendedFailure) {
+                    StatusChip(label = "FORCED", tone = ChipTone.Err)
+                } else {
+                    StatusChip(label = "REAL", tone = ChipTone.Err)
+                }
+            }
+        }
+
         Text(
-            text = event.method,
-            style = MaterialTheme.typography.labelSmall.copy(fontFamily = monoFont),
-            color = event.method.methodColor(),
+            text = event.status.value.toString(),
+            style = MaterialTheme.typography.labelSmall.copy(
+                fontFamily = monoFont,
+                fontWeight = FontWeight.SemiBold,
+            ),
+            color = event.status.statusColor(event.isIntendedFailure),
+            textAlign = TextAlign.End,
+            modifier = Modifier.defaultMinSize(minWidth = 32.dp),
         )
-        Spacer(Modifier.width(2.dp))
-        Text(
-            modifier = Modifier.weight(1f),
-            text = event.url,
-            style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
-            color = colorScheme.onSurfaceVariant,
-            maxLines = 1,
-        )
+
         Text(
             text = "${event.delay}ms",
             style = MaterialTheme.typography.labelSmall.copy(fontFamily = monoFont),
-            color = if ((event.delay ?: 0) > 1000) colorScheme.warning.primary else colorScheme.onSurfaceFaint,
+            color = when {
+                isRealError -> errorColor
+                isSlowRequest -> slowColor
+                else -> faintColor
+            },
+            textAlign = TextAlign.End,
+            modifier = Modifier.defaultMinSize(minWidth = 52.dp),
         )
     }
 }
@@ -144,28 +280,52 @@ fun MonitorLogsWidgetPreview() = PreviewSurface {
         state = MonitorLogsViewModel.State.DisplayLogs(
             entries = sequenceOf(
                 LogEvent(
-                    timestamp = 1000,
+                    timestamp = 1_716_566_657_201,
                     url = "https://www.example.com/repairs/list",
-                    requestBody = "request body",
+                    requestBody = "",
                     requestHeaders = mapOf(),
                     responseHeaders = mapOf(),
-                    responseBody = "response body",
+                    responseBody = """{"items":[{"id":1,"status":"upcoming"}]}""",
                     status = HttpStatusCode.OK,
-                    delay = 50,
+                    delay = 342,
                     method = "GET",
                     isIntendedFailure = false,
                 ),
                 LogEvent(
-                    timestamp = 2000,
-                    url = "https://www.example.com/auth/login",
-                    requestBody = "{}",
+                    timestamp = 1_716_566_659_014,
+                    url = "https://www.example.com/customer/get",
+                    requestBody = "",
                     requestHeaders = mapOf(),
                     responseHeaders = mapOf(),
-                    responseBody = "{}",
-                    status = HttpStatusCode.NotFound,
-                    delay = 1200,
+                    responseBody = """{"id":42,"name":"John"}""",
+                    status = HttpStatusCode.OK,
+                    delay = 12,
+                    method = "GET",
+                    isIntendedFailure = false,
+                ),
+                LogEvent(
+                    timestamp = 1_716_566_661_889,
+                    url = "https://www.example.com/auth/token",
+                    requestBody = """{"user":"test"}""",
+                    requestHeaders = mapOf(),
+                    responseHeaders = mapOf(),
+                    responseBody = """{"error":"forced failure"}""",
+                    status = HttpStatusCode.InternalServerError,
+                    delay = 1,
                     method = "POST",
                     isIntendedFailure = true,
+                ),
+                LogEvent(
+                    timestamp = 1_716_566_664_501,
+                    url = "https://www.example.com/repairs/expired",
+                    requestBody = "",
+                    requestHeaders = mapOf(),
+                    responseHeaders = mapOf(),
+                    responseBody = """{"error":"unauthorised"}""",
+                    status = HttpStatusCode.Unauthorized,
+                    delay = 1502,
+                    method = "GET",
+                    isIntendedFailure = false,
                 ),
             ),
         ),
@@ -176,37 +336,44 @@ fun MonitorLogsWidgetPreview() = PreviewSurface {
 
 @Composable
 private fun MonitorLogsList(
-    entries: Sequence<LogEvent>,
+    entryList: List<LogEvent>,
+    panelBg: Color,
     onViewDetail: (LogEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val colorScheme = MaterialTheme.colorScheme
-    val state = rememberLazyListState()
-    val entryList = entries.toList()
+    val listState = rememberLazyListState()
     var previousSize by remember { mutableStateOf(entryList.size) }
+
     LaunchedEffect(previousSize, entryList.size) {
         val previous = previousSize
         val current = entryList.size
         if (previous != current) {
             if (current > previous) {
-                val previousLastItemIndex = state.layoutInfo.visibleItemsInfo.maxOf { it.index }
+                val previousLastItemIndex = listState.layoutInfo.visibleItemsInfo.maxOf { it.index }
                 if (previousLastItemIndex >= previous - 1) {
-                    state.scrollToItem(entryList.lastIndex)
+                    listState.scrollToItem(entryList.lastIndex)
                 }
             }
             previousSize = current
         }
     }
-    LazyColumn(modifier = modifier, state = state) {
-        entryList.forEachIndexed { index, logEvent ->
-            item {
-                LogRow(
+
+    LazyColumn(modifier = modifier, state = listState) {
+        entryList.forEach { logEvent ->
+            item(key = logEvent.timestamp) {
+                Column(
                     modifier = Modifier
-                        .clickable(onClick = { onViewDetail(logEvent) }, role = Role.Button)
                         .fillMaxWidth()
-                        .background(if (index % 2 == 0) colorScheme.surface else colorScheme.surfaceContainer),
-                    event = logEvent,
-                )
+                        .background(panelBg),
+                ) {
+                    LogRow(
+                        modifier = Modifier
+                            .clickable(onClick = { onViewDetail(logEvent) }, role = Role.Button)
+                            .fillMaxWidth(),
+                        event = logEvent,
+                    )
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outline)
+                }
             }
         }
     }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/MonitorLogsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/MonitorLogsWidget.kt
@@ -62,7 +62,7 @@ import com.apadmi.mockzilla.ui.ui.common.theme.warning
 import io.ktor.http.HttpStatusCode
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
-import kotlin.time.Instant
+import kotlinx.datetime.Instant
 
 /** Extracts `HH:mm:ss.mmm` from epoch millis (UTC). */
 private fun Long.formatTimestamp(): String =
@@ -123,7 +123,7 @@ fun MonitorLogsWidgetContent(
     var isExpanded by remember { mutableStateOf(false) }
     val chevronRotation by animateFloatAsState(
         targetValue = if (isExpanded) 90f else 0f,
-        animationSpec = tween(durationMillis = 250),
+        animationSpec = tween(durationMillis = 150),
         label = "chevronRotation",
     )
 
@@ -173,12 +173,12 @@ fun MonitorLogsWidgetContent(
             visible = isExpanded,
             enter = expandVertically(
                 expandFrom = Alignment.Top,
-                animationSpec = tween(durationMillis = 320),
-            ) + fadeIn(animationSpec = tween(durationMillis = 220)),
+                animationSpec = tween(durationMillis = 160),
+            ) + fadeIn(animationSpec = tween(durationMillis = 120)),
             exit = shrinkVertically(
                 shrinkTowards = Alignment.Top,
-                animationSpec = tween(durationMillis = 260),
-            ) + fadeOut(animationSpec = tween(durationMillis = 180)),
+                animationSpec = tween(durationMillis = 130),
+            ) + fadeOut(animationSpec = tween(durationMillis = 100)),
         ) {
             MonitorLogsList(
                 entryList = entryList,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/MonitorLogsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/MonitorLogsWidget.kt
@@ -151,12 +151,12 @@ fun MonitorLogsWidgetContent(
             )
             Canvas(modifier = Modifier.size(6.dp)) { drawCircle(color = streamingColor) }
             Text(
-                text = "STREAMING",
+                text = strings.widgets.logs.streaming,
                 style = MaterialTheme.typography.labelSmall.copy(fontFamily = monoFont),
                 color = streamingColor,
             )
             Text(
-                text = "·  CLICK ROW TO INSPECT",
+                text = strings.widgets.logs.clickToInspect,
                 style = MaterialTheme.typography.labelSmall.copy(fontFamily = monoFont),
                 color = faintColor,
             )

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
@@ -67,6 +67,44 @@ private fun StringBuilder.appendNewlineIndent(depth: Int) {
 }
 
 /**
+ * Processes a single character from [source] at [startIdx] during JSON pretty-printing,
+ * appending the formatted output to the receiver [StringBuilder].
+ *
+ * @return A pair of (next index to process, updated nesting depth).
+ */
+private fun StringBuilder.processPrettyJsonChar(
+    source: String,
+    startIdx: Int,
+    depth: Int,
+): Pair<Int, Int> = when (source[startIdx]) {
+    '{', '[' -> {
+        append(source[startIdx])
+        appendNewlineIndent(depth + 1)
+        startIdx + 1 to depth + 1
+    }
+    '}', ']' -> {
+        appendNewlineIndent(depth - 1)
+        append(source[startIdx])
+        startIdx + 1 to depth - 1
+    }
+    ',' -> {
+        append(',')
+        appendNewlineIndent(depth)
+        startIdx + 1 to depth
+    }
+    ':' -> {
+        append(": ")
+        startIdx + 1 to depth
+    }
+    '"' -> appendJsonString(source, startIdx, this) + 1 to depth
+    ' ', '\t', '\r', '\n' -> startIdx + 1 to depth
+    else -> {
+        append(source[startIdx])
+        startIdx + 1 to depth
+    }
+}
+
+/**
  * Reads a JSON string literal (including surrounding quotes and escape sequences)
  * from [source] starting at [openQuoteIdx], appending each character to [sink].
  *
@@ -94,7 +132,6 @@ private fun appendJsonString(source: String, openQuoteIdx: Int, sink: StringBuil
     return idx - 1
 }
 
-@Suppress("TOO_LONG_FUNCTION")
 internal fun String.prettyPrintJson(): String {
     val trimmed = trim()
     if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return this
@@ -102,27 +139,9 @@ internal fun String.prettyPrintJson(): String {
     var depth = 0
     var idx = 0
     while (idx < trimmed.length) {
-        when (trimmed[idx]) {
-            '{', '[' -> {
-                sb.append(trimmed[idx])
-                depth++
-                sb.appendNewlineIndent(depth)
-            }
-            '}', ']' -> {
-                depth--
-                sb.appendNewlineIndent(depth)
-                sb.append(trimmed[idx])
-            }
-            ',' -> {
-                sb.append(',')
-                sb.appendNewlineIndent(depth)
-            }
-            ':' -> sb.append(": ")
-            '"' -> idx = appendJsonString(trimmed, idx, sb)
-            ' ', '\t', '\r', '\n' -> Unit
-            else -> sb.append(trimmed[idx])
-        }
-        idx++
+        val (newIdx, newDepth) = sb.processPrettyJsonChar(trimmed, idx, depth)
+        idx = newIdx
+        depth = newDepth
     }
     return sb.toString()
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
@@ -1,4 +1,4 @@
-@file:Suppress("COMPLEX_EXPRESSION", "FILE_NAME_MATCH_CLASS")
+@file:Suppress("FILE_NAME_MATCH_CLASS")
 
 package com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details
 
@@ -8,11 +8,15 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
 
-import kotlin.time.Instant
+import kotlinx.datetime.Instant
+import kotlinx.datetime.format
+import kotlinx.datetime.format.DateTimeComponents
+import kotlinx.datetime.format.char
 
 internal const val BYTES_PER_KB = 1024
 internal const val TENTHS_FACTOR = 10
 internal const val ALPHA_MUTED = 0.5f
+private const val JSON_INDENT = "  "
 
 /**
  * @property keyColor Color for JSON object keys.
@@ -34,54 +38,85 @@ internal fun String.toKbLabel(): String {
     return "${tenths / TENTHS_FACTOR}.${tenths % TENTHS_FACTOR} KB"
 }
 
-@Suppress("TOO_LONG_FUNCTION", "NESTED_BLOCK")
+internal fun urlToTitle(url: String): String = url
+    .trimEnd('/')
+    .substringAfterLast('/')
+    .substringBefore('?')
+    .replaceFirstChar { it.uppercaseChar() }
+    .ifBlank { url }
+
+private val TIMESTAMP_FORMAT = DateTimeComponents.Format {
+    hour()
+    char(':')
+    minute()
+    char(':')
+    second()
+    char('.')
+    secondFraction(3)
+}
+
+internal fun formatTimestamp(timestamp: Long): String =
+    Instant.fromEpochMilliseconds(timestamp).format(TIMESTAMP_FORMAT)
+
+// ── JSON pretty-printer ───────────────────────────────────────────────────────
+
+private fun StringBuilder.appendNewlineIndent(depth: Int) {
+    append('\n')
+    repeat(depth) { append(JSON_INDENT) }
+}
+
+/**
+ * Reads a JSON string literal (including surrounding quotes and escape sequences)
+ * from [source] starting at [openQuoteIdx], appending each character to [sink].
+ *
+ * @return The index of the closing `"` in [source], so the caller can advance past it.
+ */
+private fun appendJsonString(source: String, openQuoteIdx: Int, sink: StringBuilder): Int {
+    sink.append('"')
+    var idx = openQuoteIdx + 1
+    while (idx < source.length) {
+        val ch = source[idx]
+        when {
+            ch == '\\' && idx + 1 < source.length -> {
+                sink.append(ch)
+                idx++
+                sink.append(source[idx])
+            }
+            ch == '"' -> {
+                sink.append(ch)
+                return idx
+            }
+            else -> sink.append(ch)
+        }
+        idx++
+    }
+    return idx - 1
+}
+
 internal fun String.prettyPrintJson(): String {
     val trimmed = trim()
-    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
-        return this
-    }
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return this
     val sb = StringBuilder()
-    var indent = 0
-    val indentStr = "  "
+    var depth = 0
     var idx = 0
     while (idx < trimmed.length) {
         when (trimmed[idx]) {
             '{', '[' -> {
                 sb.append(trimmed[idx])
-                indent++
-                sb.append('\n')
-                repeat(indent) { sb.append(indentStr) }
+                depth++
+                sb.appendNewlineIndent(depth)
             }
             '}', ']' -> {
-                indent--
-                sb.append('\n')
-                repeat(indent) { sb.append(indentStr) }
+                depth--
+                sb.appendNewlineIndent(depth)
                 sb.append(trimmed[idx])
             }
             ',' -> {
                 sb.append(',')
-                sb.append('\n')
-                repeat(indent) { sb.append(indentStr) }
+                sb.appendNewlineIndent(depth)
             }
             ':' -> sb.append(": ")
-            '"' -> {
-                sb.append('"')
-                idx++
-                while (idx < trimmed.length) {
-                    val ch = trimmed[idx]
-                    if (ch == '\\' && idx + 1 < trimmed.length) {
-                        sb.append(ch)
-                        idx++
-                        sb.append(trimmed[idx])
-                    } else if (ch == '"') {
-                        sb.append(ch)
-                        break
-                    } else {
-                        sb.append(ch)
-                    }
-                    idx++
-                }
-            }
+            '"' -> idx = appendJsonString(trimmed, idx, sb)
             ' ', '\t', '\r', '\n' -> Unit
             else -> sb.append(trimmed[idx])
         }
@@ -90,88 +125,93 @@ internal fun String.prettyPrintJson(): String {
     return sb.toString()
 }
 
-internal fun urlToTitle(url: String): String = url
-    .trimEnd('/')
-    .substringAfterLast('/')
-    .substringBefore('?')
-    .replaceFirstChar { it.uppercaseChar() }
-    .ifBlank { url }
+// ── JSON syntax highlighter ───────────────────────────────────────────────────
 
-internal fun formatTimestamp(timestamp: Long): String {
-    val raw = Instant.fromEpochMilliseconds(timestamp)
-        .toString()
-        .substringAfterLast('T')
-        .removeSuffix("Z")
-    return if ('.' in raw) {
-        raw.substringBefore('.') + "." + raw.substringAfter('.').take(3)
-    } else {
-        raw
+/**
+ * Reads a quoted JSON string token from [text] starting at [startIdx] (the opening `"`).
+ *
+ * @return The full token (including surrounding quotes) and the index immediately
+ * after the closing `"`.
+ */
+private fun readStringToken(text: String, startIdx: Int): Pair<String, Int> {
+    var idx = startIdx + 1
+    while (idx < text.length) {
+        when {
+            text[idx] == '\\' -> idx++  // skip the escaped character
+            text[idx] == '"' -> return text.substring(startIdx, idx + 1) to idx + 1
+        }
+        idx++
     }
+    return text.substring(startIdx, idx) to idx
 }
 
-@Suppress("IDENTIFIER_LENGTH", "TOO_LONG_FUNCTION")
+/**
+ * Returns `true` if the first non-whitespace character at or after [fromIdx] is `:`,
+ * meaning the token that preceded it is a JSON object key.
+ */
+private fun isFollowedByColon(text: String, fromIdx: Int): Boolean {
+    var idx = fromIdx
+    while (idx < text.length && text[idx] in " \t\r\n") idx++
+    return idx < text.length && text[idx] == ':'
+}
+
+/**
+ * Returns `true` if the character at [idx] in [text] is the start of a JSON number
+ * (a digit, or a `-` followed by a digit).
+ */
+private fun isNumberStart(text: String, idx: Int): Boolean =
+    text[idx].isDigit() || (text[idx] == '-' && idx + 1 < text.length && text[idx + 1].isDigit())
+
+/**
+ * Reads a JSON number token (optional `-`, digits, optional decimal part) from [text]
+ * starting at [startIdx].
+ *
+ * @return The token string and the index immediately after the number.
+ */
+private fun readNumberToken(text: String, startIdx: Int): Pair<String, Int> {
+    var idx = startIdx
+    if (idx < text.length && text[idx] == '-') idx++
+    while (idx < text.length && (text[idx].isDigit() || text[idx] == '.')) idx++
+    return text.substring(startIdx, idx) to idx
+}
+
 internal fun buildJsonAnnotatedString(text: String, colors: JsonHighlightColors): AnnotatedString {
     val pretty = text.prettyPrintJson()
     return buildAnnotatedString {
-        if (pretty.isBlank() ||
-                (!pretty.trimStart().startsWith('{') && !pretty.trimStart().startsWith('['))
-        ) {
+        val trimmedStart = pretty.trimStart()
+        if (pretty.isBlank() || (!trimmedStart.startsWith('{') && !trimmedStart.startsWith('['))) {
             append(pretty)
             return@buildAnnotatedString
         }
-        var ci = 0
-        while (ci < pretty.length) {
+        var charIdx = 0
+        while (charIdx < pretty.length) {
             when {
-                pretty[ci] == '"' -> {
-                    val start = ci++
-                    while (ci < pretty.length) {
-                        if (pretty[ci] == '\\') {
-                            ci++
-                        }
-                        if (ci >= pretty.length) {
-                            break
-                        }
-                        if (pretty[ci] == '"') {
-                            ci++
-                            break
-                        }
-                        ci++
-                    }
-                    val token = pretty.substring(start, ci)
-                    var peek = ci
-                    while (peek < pretty.length && pretty[peek] in " \t\r\n") {
-                        peek++
-                    }
-                    val isKey = peek < pretty.length && pretty[peek] == ':'
-                    withStyle(SpanStyle(color = if (isKey) colors.keyColor else colors.stringColor)) {
-                        append(token)
-                    }
+                pretty[charIdx] == '"' -> {
+                    val (token, next) = readStringToken(pretty, charIdx)
+                    val color = if (isFollowedByColon(pretty, next)) colors.keyColor else colors.stringColor
+                    withStyle(SpanStyle(color = color)) { append(token) }
+                    charIdx = next
                 }
-                pretty[ci].isDigit() || (pretty[ci] == '-' && ci + 1 < pretty.length && pretty[ci + 1].isDigit()) -> {
-                    val start = ci
-                    if (pretty[ci] == '-') {
-                        ci++
-                    }
-                    while (ci < pretty.length && (pretty[ci].isDigit() || pretty[ci] == '.')) {
-                        ci++
-                    }
-                    withStyle(SpanStyle(color = colors.numberColor)) { append(pretty.substring(start, ci)) }
+                isNumberStart(pretty, charIdx) -> {
+                    val (token, next) = readNumberToken(pretty, charIdx)
+                    withStyle(SpanStyle(color = colors.numberColor)) { append(token) }
+                    charIdx = next
                 }
-                ci + 4 <= pretty.length && pretty.substring(ci, ci + 4) == "true" -> {
+                pretty.startsWith("true", charIdx) -> {
                     withStyle(SpanStyle(color = colors.boolColor)) { append("true") }
-                    ci += 4
+                    charIdx += 4
                 }
-                ci + 5 <= pretty.length && pretty.substring(ci, ci + 5) == "false" -> {
+                pretty.startsWith("false", charIdx) -> {
                     withStyle(SpanStyle(color = colors.boolColor)) { append("false") }
-                    ci += 5
+                    charIdx += 5
                 }
-                ci + 4 <= pretty.length && pretty.substring(ci, ci + 4) == "null" -> {
+                pretty.startsWith("null", charIdx) -> {
                     withStyle(SpanStyle(color = colors.nullColor)) { append("null") }
-                    ci += 4
+                    charIdx += 4
                 }
                 else -> {
-                    append(pretty[ci])
-                    ci++
+                    append(pretty[charIdx])
+                    charIdx++
                 }
             }
         }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
@@ -18,6 +18,9 @@ internal const val TENTHS_FACTOR = 10
 internal const val ALPHA_MUTED = 0.5f
 private const val JSON_INDENT = "  "
 private const val MILLISECONDS_FRACTION_DIGITS = 3
+private const val JSON_TRUE_LENGTH = 4
+private const val JSON_FALSE_LENGTH = 5
+private const val JSON_NULL_LENGTH = 4
 
 /**
  * @property keyColor Color for JSON object keys.
@@ -220,15 +223,15 @@ private fun AnnotatedString.Builder.processHighlightToken(
     }
     text.startsWith("true", charIdx) -> {
         withStyle(SpanStyle(color = colors.boolColor)) { append("true") }
-        charIdx + 4
+        charIdx + JSON_TRUE_LENGTH
     }
     text.startsWith("false", charIdx) -> {
         withStyle(SpanStyle(color = colors.boolColor)) { append("false") }
-        charIdx + 5
+        charIdx + JSON_FALSE_LENGTH
     }
     text.startsWith("null", charIdx) -> {
         withStyle(SpanStyle(color = colors.nullColor)) { append("null") }
-        charIdx + 4
+        charIdx + JSON_NULL_LENGTH
     }
     else -> {
         append(text[charIdx])

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
@@ -1,0 +1,179 @@
+@file:Suppress("COMPLEX_EXPRESSION", "FILE_NAME_MATCH_CLASS")
+
+package com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+
+import kotlin.time.Instant
+
+internal const val BYTES_PER_KB = 1024
+internal const val TENTHS_FACTOR = 10
+internal const val ALPHA_MUTED = 0.5f
+
+/**
+ * @property keyColor Color for JSON object keys.
+ * @property stringColor Color for JSON string values.
+ * @property numberColor Color for JSON numeric values.
+ * @property boolColor Color for JSON boolean values.
+ * @property nullColor Color for JSON null values.
+ */
+internal data class JsonHighlightColors(
+    val keyColor: Color,
+    val stringColor: Color,
+    val numberColor: Color,
+    val boolColor: Color,
+    val nullColor: Color,
+)
+
+internal fun String.toKbLabel(): String {
+    val tenths = encodeToByteArray().size * TENTHS_FACTOR / BYTES_PER_KB
+    return "${tenths / TENTHS_FACTOR}.${tenths % TENTHS_FACTOR} KB"
+}
+
+@Suppress("TOO_LONG_FUNCTION", "NESTED_BLOCK")
+internal fun String.prettyPrintJson(): String {
+    val trimmed = trim()
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+        return this
+    }
+    val sb = StringBuilder()
+    var indent = 0
+    val indentStr = "  "
+    var idx = 0
+    while (idx < trimmed.length) {
+        when (trimmed[idx]) {
+            '{', '[' -> {
+                sb.append(trimmed[idx])
+                indent++
+                sb.append('\n')
+                repeat(indent) { sb.append(indentStr) }
+            }
+            '}', ']' -> {
+                indent--
+                sb.append('\n')
+                repeat(indent) { sb.append(indentStr) }
+                sb.append(trimmed[idx])
+            }
+            ',' -> {
+                sb.append(',')
+                sb.append('\n')
+                repeat(indent) { sb.append(indentStr) }
+            }
+            ':' -> sb.append(": ")
+            '"' -> {
+                sb.append('"')
+                idx++
+                while (idx < trimmed.length) {
+                    val ch = trimmed[idx]
+                    if (ch == '\\' && idx + 1 < trimmed.length) {
+                        sb.append(ch)
+                        idx++
+                        sb.append(trimmed[idx])
+                    } else if (ch == '"') {
+                        sb.append(ch)
+                        break
+                    } else {
+                        sb.append(ch)
+                    }
+                    idx++
+                }
+            }
+            ' ', '\t', '\r', '\n' -> Unit
+            else -> sb.append(trimmed[idx])
+        }
+        idx++
+    }
+    return sb.toString()
+}
+
+internal fun urlToTitle(url: String): String = url
+    .trimEnd('/')
+    .substringAfterLast('/')
+    .substringBefore('?')
+    .replaceFirstChar { it.uppercaseChar() }
+    .ifBlank { url }
+
+internal fun formatTimestamp(timestamp: Long): String {
+    val raw = Instant.fromEpochMilliseconds(timestamp)
+        .toString()
+        .substringAfterLast('T')
+        .removeSuffix("Z")
+    return if ('.' in raw) {
+        raw.substringBefore('.') + "." + raw.substringAfter('.').take(3)
+    } else {
+        raw
+    }
+}
+
+@Suppress("IDENTIFIER_LENGTH", "TOO_LONG_FUNCTION")
+internal fun buildJsonAnnotatedString(text: String, colors: JsonHighlightColors): AnnotatedString {
+    val pretty = text.prettyPrintJson()
+    return buildAnnotatedString {
+        if (pretty.isBlank() ||
+                (!pretty.trimStart().startsWith('{') && !pretty.trimStart().startsWith('['))
+        ) {
+            append(pretty)
+            return@buildAnnotatedString
+        }
+        var ci = 0
+        while (ci < pretty.length) {
+            when {
+                pretty[ci] == '"' -> {
+                    val start = ci++
+                    while (ci < pretty.length) {
+                        if (pretty[ci] == '\\') {
+                            ci++
+                        }
+                        if (ci >= pretty.length) {
+                            break
+                        }
+                        if (pretty[ci] == '"') {
+                            ci++
+                            break
+                        }
+                        ci++
+                    }
+                    val token = pretty.substring(start, ci)
+                    var peek = ci
+                    while (peek < pretty.length && pretty[peek] in " \t\r\n") {
+                        peek++
+                    }
+                    val isKey = peek < pretty.length && pretty[peek] == ':'
+                    withStyle(SpanStyle(color = if (isKey) colors.keyColor else colors.stringColor)) {
+                        append(token)
+                    }
+                }
+                pretty[ci].isDigit() || (pretty[ci] == '-' && ci + 1 < pretty.length && pretty[ci + 1].isDigit()) -> {
+                    val start = ci
+                    if (pretty[ci] == '-') {
+                        ci++
+                    }
+                    while (ci < pretty.length && (pretty[ci].isDigit() || pretty[ci] == '.')) {
+                        ci++
+                    }
+                    withStyle(SpanStyle(color = colors.numberColor)) { append(pretty.substring(start, ci)) }
+                }
+                ci + 4 <= pretty.length && pretty.substring(ci, ci + 4) == "true" -> {
+                    withStyle(SpanStyle(color = colors.boolColor)) { append("true") }
+                    ci += 4
+                }
+                ci + 5 <= pretty.length && pretty.substring(ci, ci + 5) == "false" -> {
+                    withStyle(SpanStyle(color = colors.boolColor)) { append("false") }
+                    ci += 5
+                }
+                ci + 4 <= pretty.length && pretty.substring(ci, ci + 4) == "null" -> {
+                    withStyle(SpanStyle(color = colors.nullColor)) { append("null") }
+                    ci += 4
+                }
+                else -> {
+                    append(pretty[ci])
+                    ci++
+                }
+            }
+        }
+    }
+}

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
@@ -196,6 +196,46 @@ private fun readNumberToken(text: String, startIdx: Int): Pair<String, Int> {
     return text.substring(startIdx, idx) to idx
 }
 
+/**
+ * Processes a single character (or token) at [charIdx] in [text] during JSON syntax
+ * highlighting, appending styled spans to the receiver [AnnotatedString.Builder].
+ *
+ * @return The index of the next character to process.
+ */
+private fun AnnotatedString.Builder.processHighlightToken(
+    text: String,
+    charIdx: Int,
+    colors: JsonHighlightColors,
+): Int = when {
+    text[charIdx] == '"' -> {
+        val (token, next) = readStringToken(text, charIdx)
+        val color = if (isFollowedByColon(text, next)) colors.keyColor else colors.stringColor
+        withStyle(SpanStyle(color = color)) { append(token) }
+        next
+    }
+    isNumberStart(text, charIdx) -> {
+        val (token, next) = readNumberToken(text, charIdx)
+        withStyle(SpanStyle(color = colors.numberColor)) { append(token) }
+        next
+    }
+    text.startsWith("true", charIdx) -> {
+        withStyle(SpanStyle(color = colors.boolColor)) { append("true") }
+        charIdx + 4
+    }
+    text.startsWith("false", charIdx) -> {
+        withStyle(SpanStyle(color = colors.boolColor)) { append("false") }
+        charIdx + 5
+    }
+    text.startsWith("null", charIdx) -> {
+        withStyle(SpanStyle(color = colors.nullColor)) { append("null") }
+        charIdx + 4
+    }
+    else -> {
+        append(text[charIdx])
+        charIdx + 1
+    }
+}
+
 internal fun buildJsonAnnotatedString(text: String, colors: JsonHighlightColors): AnnotatedString {
     val pretty = text.prettyPrintJson()
     return buildAnnotatedString {
@@ -206,35 +246,7 @@ internal fun buildJsonAnnotatedString(text: String, colors: JsonHighlightColors)
         }
         var charIdx = 0
         while (charIdx < pretty.length) {
-            when {
-                pretty[charIdx] == '"' -> {
-                    val (token, next) = readStringToken(pretty, charIdx)
-                    val color = if (isFollowedByColon(pretty, next)) colors.keyColor else colors.stringColor
-                    withStyle(SpanStyle(color = color)) { append(token) }
-                    charIdx = next
-                }
-                isNumberStart(pretty, charIdx) -> {
-                    val (token, next) = readNumberToken(pretty, charIdx)
-                    withStyle(SpanStyle(color = colors.numberColor)) { append(token) }
-                    charIdx = next
-                }
-                pretty.startsWith("true", charIdx) -> {
-                    withStyle(SpanStyle(color = colors.boolColor)) { append("true") }
-                    charIdx += 4
-                }
-                pretty.startsWith("false", charIdx) -> {
-                    withStyle(SpanStyle(color = colors.boolColor)) { append("false") }
-                    charIdx += 5
-                }
-                pretty.startsWith("null", charIdx) -> {
-                    withStyle(SpanStyle(color = colors.nullColor)) { append("null") }
-                    charIdx += 4
-                }
-                else -> {
-                    append(pretty[charIdx])
-                    charIdx++
-                }
-            }
+            charIdx = processHighlightToken(pretty, charIdx, colors)
         }
     }
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsFormatters.kt
@@ -17,6 +17,7 @@ internal const val BYTES_PER_KB = 1024
 internal const val TENTHS_FACTOR = 10
 internal const val ALPHA_MUTED = 0.5f
 private const val JSON_INDENT = "  "
+private const val MILLISECONDS_FRACTION_DIGITS = 3
 
 /**
  * @property keyColor Color for JSON object keys.
@@ -52,7 +53,7 @@ private val TIMESTAMP_FORMAT = DateTimeComponents.Format {
     char(':')
     second()
     char('.')
-    secondFraction(3)
+    secondFraction(MILLISECONDS_FRACTION_DIGITS)
 }
 
 internal fun formatTimestamp(timestamp: Long): String =
@@ -93,6 +94,7 @@ private fun appendJsonString(source: String, openQuoteIdx: Int, sink: StringBuil
     return idx - 1
 }
 
+@Suppress("TOO_LONG_FUNCTION")
 internal fun String.prettyPrintJson(): String {
     val trimmed = trim()
     if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return this

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsViewModel.kt
@@ -8,47 +8,20 @@ import kotlinx.coroutines.flow.update
 class MonitorLogDetailsViewModel(
     scope: CoroutineScope? = null
 ) : ViewModel(scope) {
-    val state = MutableStateFlow(
-        State.ViewDetails(
-            requestHeaders = false,
-            requestBody = false,
-            responseHeaders = false,
-            responseBody = true
-        )
-    )
+    val state = MutableStateFlow(State.ViewDetails())
 
-    fun onViewRequestHeaders(view: Boolean) = updateState { state ->
-        state.copy(requestHeaders = view)
-    }
-
-    fun onViewRequestBody(view: Boolean) = updateState { state ->
-        state.copy(requestBody = view)
-    }
-
-    fun onViewResponseHeaders(view: Boolean) = updateState { state ->
-        state.copy(responseHeaders = view)
-    }
-
-    fun onViewResponseBody(view: Boolean) = updateState { state ->
-        state.copy(responseBody = view)
-    }
-
-    private fun updateState(
-        update: (State.ViewDetails) -> State.ViewDetails
-    ) = state.update(update)
+    fun onTabSelected(tab: State.ViewDetails.Tab) = state.update { it.copy(selectedTab = tab) }
 
     sealed class State {
         /**
-         * @property requestHeaders
-         * @property requestBody
-         * @property responseHeaders
-         * @property responseBody
+         * @property selectedTab
          */
         data class ViewDetails(
-            val requestHeaders: Boolean,
-            val requestBody: Boolean,
-            val responseHeaders: Boolean,
-            val responseBody: Boolean,
-        ) : State()
+            val selectedTab: Tab = Tab.Response,
+        ) : State() {
+            enum class Tab {
+                Request, Response
+            }
+        }
     }
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -313,23 +313,9 @@ private fun LogTabBar(selectedTab: Tab, onTabSelected: (Tab) -> Unit) {
 @Composable
 private fun BodyContent(body: String, strings: Strings) {
     val monoFont = LocalMonoFontFamily.current
-    if (body.isEmpty()) {
-        Text(
-            text = strings.widgets.logDetails.noBody,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
-            modifier = Modifier.padding(vertical = 4.dp),
-        )
-        return
-    }
     val cs = MaterialTheme.colorScheme
-    val jsonColors = JsonHighlightColors(
-        keyColor = cs.jsonKey,
-        stringColor = cs.success.primary,
-        numberColor = cs.tertiary,
-        boolColor = cs.warning.primary,
-        nullColor = cs.onSurface.copy(alpha = ALPHA_MUTED),
-    )
+    val trimmed = body.trim()
+    val isEmpty = trimmed.isEmpty() || trimmed == "{}" || trimmed == "[]"
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -339,11 +325,26 @@ private fun BodyContent(body: String, strings: Strings) {
             )
             .padding(10.dp),
     ) {
-        SelectionContainer {
+        if (isEmpty) {
             Text(
-                text = buildJsonAnnotatedString(body, jsonColors),
+                text = strings.widgets.logDetails.emptyBody,
                 style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
+                color = cs.onSurface.copy(alpha = 0.5f),
             )
+        } else {
+            val jsonColors = JsonHighlightColors(
+                keyColor = cs.jsonKey,
+                stringColor = cs.success.primary,
+                numberColor = cs.tertiary,
+                boolColor = cs.warning.primary,
+                nullColor = cs.onSurface.copy(alpha = ALPHA_MUTED),
+            )
+            SelectionContainer {
+                Text(
+                    text = buildJsonAnnotatedString(body, jsonColors),
+                    style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
+                )
+            }
         }
     }
 }
@@ -374,7 +375,7 @@ private fun HeadersContent(headers: List<Pair<String, String>>, strings: Strings
                     Text(
                         text = key,
                         style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
-                        color = MaterialTheme.colorScheme.tertiary,
+                        color = MaterialTheme.colorScheme.jsonKey,
                         modifier = Modifier.weight(0.4f),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -237,6 +237,7 @@ private fun LogStatusBadge(status: HttpStatusCode) {
         text = status.value.toString(),
         modifier = Modifier
             .border(width = 1.5.dp, color = statusColor, shape = RoundedCornerShape(percent = 50))
+            .background(color = statusColor.copy(alpha = 0.1f), shape = RoundedCornerShape(percent = 50))
             .padding(horizontal = 8.dp, vertical = 3.dp),
         style = MaterialTheme.typography.labelMedium.copy(fontFamily = monoFont),
         color = statusColor,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -17,9 +17,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -94,9 +99,9 @@ fun LogDetailsContent(
     strings: Strings = LocalStrings.current,
 ) = Column(modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
     LogHeaderBar(logDetail = logDetail, onClose = onClose)
-    HorizontalDivider()
+    HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
     LogTabBar(selectedTab = state.selectedTab, onTabSelected = onTabSelected)
-    HorizontalDivider()
+    HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -197,14 +202,13 @@ private fun LogHeaderBar(logDetail: LogEvent, onClose: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurface,
                 modifier = Modifier.weight(1f),
             )
-            Text(
-                text = "×",
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier
-                    .clickable(onClick = onClose)
-                    .padding(4.dp),
-            )
+            IconButton(onClick = onClose) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
         }
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -273,18 +277,24 @@ private fun MetaItem(
 
 @Suppress("MAGIC_NUMBER")
 @Composable
-private fun LogTabBar(selectedTab: Tab, onTabSelected: (Tab) -> Unit) {
-    Row(modifier = Modifier.fillMaxWidth()) {
+private fun LogTabBar(
+    selectedTab: Tab,
+    onTabSelected: (Tab) -> Unit,
+) {
+    Row {
         Tab.entries.forEach { tab ->
+
             val isSelected = tab == selectedTab
+
             val selectedColor = if (isSelected) {
                 MaterialTheme.colorScheme.primary
             } else {
                 MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
             }
+
             Column(
                 modifier = Modifier
-                    .weight(1f)
+                    .width(100.dp)  // Fixed width
                     .clickable { onTabSelected(tab) },
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
@@ -292,22 +302,30 @@ private fun LogTabBar(selectedTab: Tab, onTabSelected: (Tab) -> Unit) {
                     text = tab.name,
                     modifier = Modifier.padding(vertical = 10.dp),
                     style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                    fontWeight = if (isSelected) {
+                        FontWeight.SemiBold
+                    } else {
+                        FontWeight.Normal
+                    },
                     color = selectedColor,
                 )
+
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
                         .height(2.dp)
                         .background(
-                            if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
+                            if (isSelected) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                Color.Transparent
+                            },
                         ),
                 )
             }
         }
     }
 }
-
 // ── Content sections ──────────────────────────────────────────────────────────
 
 @Suppress("MAGIC_NUMBER")

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 import com.apadmi.mockzilla.lib.internal.models.LogEvent
@@ -187,8 +186,8 @@ private fun LogHeaderBar(logDetail: LogEvent, onClose: () -> Unit) {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f))
-            .padding(horizontal = 14.dp, vertical = 10.dp),
-        verticalArrangement = Arrangement.spacedBy(6.dp),
+            .padding(horizontal = 14.dp, vertical = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically,
@@ -212,7 +211,7 @@ private fun LogHeaderBar(logDetail: LogEvent, onClose: () -> Unit) {
         }
         Row(
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             MetaItem(icon = "⏱", label = "${logDetail.delay}ms", color = metaColor)
             MetaItem(icon = "↑", label = logDetail.requestBody.toKbLabel(), color = metaColor)
@@ -389,23 +388,19 @@ private fun HeadersContent(headers: List<Pair<String, String>>, strings: Strings
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 10.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                    verticalAlignment = Alignment.Top,
                 ) {
                     Text(
                         text = key,
                         style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
                         color = MaterialTheme.colorScheme.jsonKey,
-                        modifier = Modifier.weight(0.4f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.width(110.dp),
                     )
                     Text(
                         text = value,
                         style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
                         color = MaterialTheme.colorScheme.onSurface,
-                        modifier = Modifier.weight(0.6f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
                     )
                 }
                 DashedDivider(color = dividerColor)

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -1,30 +1,37 @@
+@file:Suppress("COMPLEX_EXPRESSION")
+
 package com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material3.Checkbox
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
 import com.apadmi.mockzilla.lib.internal.models.LogEvent
@@ -33,20 +40,25 @@ import com.apadmi.mockzilla.ui.i18n.LocalStrings
 import com.apadmi.mockzilla.ui.i18n.Strings
 import com.apadmi.mockzilla.ui.ui.common.components.EmptyState
 import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
+import com.apadmi.mockzilla.ui.ui.common.components.SectionTitle
+import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
+import com.apadmi.mockzilla.ui.ui.common.theme.jsonKey
+import com.apadmi.mockzilla.ui.ui.common.theme.success
+import com.apadmi.mockzilla.ui.ui.common.theme.warning
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.MonitorLogDetailsViewModel.State.ViewDetails
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.MonitorLogDetailsViewModel.State.ViewDetails.Tab
+
 import io.ktor.http.HttpStatusCode
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
-import kotlin.time.Instant
-
 @Composable
 fun MonitorLogDetailsWidget(
-    logDetail: LogEvent?
+    logDetail: LogEvent?,
+    onClose: () -> Unit = {},
 ) {
     val viewModel = getViewModel<MonitorLogDetailsViewModel>()
     val state by viewModel.state.collectAsState()
 
-    // We need to hoist the view model above the Crossfade so switching between logs doesn't
-    // reset the view model
     Crossfade(
         targetState = logDetail,
         animationSpec = tween(durationMillis = 200)
@@ -54,10 +66,8 @@ fun MonitorLogDetailsWidget(
         MonitorLogDetailsContent(
             logDetail = newState,
             state = state,
-            onViewRequestHeaders = viewModel::onViewRequestHeaders,
-            onViewRequestBody = viewModel::onViewRequestBody,
-            onViewResponseHeaders = viewModel::onViewResponseHeaders,
-            onViewResponseBody = viewModel::onViewResponseBody
+            onTabSelected = viewModel::onTabSelected,
+            onClose = onClose,
         )
     }
 }
@@ -66,156 +76,57 @@ fun MonitorLogDetailsWidget(
 fun MonitorLogDetailsContent(
     logDetail: LogEvent?,
     state: MonitorLogDetailsViewModel.State.ViewDetails,
-    onViewRequestHeaders: (Boolean) -> Unit,
-    onViewRequestBody: (Boolean) -> Unit,
-    onViewResponseHeaders: (Boolean) -> Unit,
-    onViewResponseBody: (Boolean) -> Unit,
+    onTabSelected: (Tab) -> Unit,
+    onClose: () -> Unit = {},
 ) {
     logDetail?.let {
-        LogDetailsContent(
-            logDetail = logDetail,
-            visible = state,
-            onViewRequestHeaders = onViewRequestHeaders,
-            onViewRequestBody = onViewRequestBody,
-            onViewResponseHeaders = onViewResponseHeaders,
-            onViewResponseBody = onViewResponseBody,
-        )
+        LogDetailsContent(logDetail = it, state = state, onTabSelected = onTabSelected, onClose = onClose)
     } ?: MonitorLogDetailsEmptyContent()
 }
 
+@Suppress("TOO_LONG_FUNCTION")
 @Composable
 fun LogDetailsContent(
     logDetail: LogEvent,
-    visible: MonitorLogDetailsViewModel.State.ViewDetails,
-    onViewRequestHeaders: (Boolean) -> Unit,
-    onViewRequestBody: (Boolean) -> Unit,
-    onViewResponseHeaders: (Boolean) -> Unit,
-    onViewResponseBody: (Boolean) -> Unit,
+    state: MonitorLogDetailsViewModel.State.ViewDetails,
+    onTabSelected: (Tab) -> Unit,
+    onClose: () -> Unit = {},
     strings: Strings = LocalStrings.current,
-) = Column(
-    modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
-    verticalArrangement = Arrangement.spacedBy(8.dp)
-) {
-    SelectionContainer {
-        Text(
-            text = "${logDetail.status} - ${logDetail.method} - ${logDetail.url}",
-            style = MaterialTheme.typography.displaySmall
-        )
-    }
-    SelectionContainer {
-        Text(
-            text = Instant.fromEpochMilliseconds(logDetail.timestamp).toString(),
-            style = MaterialTheme.typography.bodyLarge
-        )
-    }
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        SelectionContainer {
-            Text(
-                text = "${logDetail.delay} ${strings.widgets.logDetails.responseDelayUnits}",
-            )
-        }
-        Text(
-            text = if (logDetail.isIntendedFailure) {
-                strings.widgets.logDetails.intendedFailure
-            } else {
-                strings.widgets.logDetails.intendedSuccess
-            }
-        )
-    }
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+) = Column(modifier = Modifier.fillMaxWidth().background(MaterialTheme.colorScheme.surface)) {
+    LogHeaderBar(logDetail = logDetail, onClose = onClose)
+    HorizontalDivider()
+    LogTabBar(selectedTab = state.selectedTab, onTabSelected = onTabSelected)
+    HorizontalDivider()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
-        // 2 per row groups request + response toggles nicely, 3 in first row looks bad
-        maxItemsInEachRow = 2,
     ) {
-        ViewToggleCheckbox(
-            checked = visible.requestHeaders,
-            onCheckedChanged = onViewRequestHeaders,
-            title = "Request headers"
-        )
-        ViewToggleCheckbox(
-            checked = visible.requestBody,
-            onCheckedChanged = onViewRequestBody,
-            title = strings.widgets.logDetails.requestBody
-        )
-        ViewToggleCheckbox(
-            checked = visible.responseHeaders,
-            onCheckedChanged = onViewResponseHeaders,
-            title = "Response headers"
-        )
-        ViewToggleCheckbox(
-            checked = visible.responseBody,
-            onCheckedChanged = onViewResponseBody,
-            title = strings.widgets.logDetails.responseBody
-        )
-    }
-    Column {
-        AnimatedVisibility(visible = visible.requestHeaders) {
-            HeaderDetail(
-                title = strings.widgets.logDetails.requestHeaders,
-                headers = logDetail.requestHeaders.toList()
-            )
-        }
-        AnimatedVisibility(visible = visible.requestBody) {
-            BodyDetail(
-                title = strings.widgets.logDetails.requestBody,
-                body = logDetail.requestBody
-            )
-        }
-        AnimatedVisibility(visible = visible.responseHeaders) {
-            HeaderDetail(
-                title = strings.widgets.logDetails.responseHeaders,
-                headers = logDetail.responseHeaders.toList()
-            )
-        }
-        AnimatedVisibility(visible = visible.responseBody) {
-            BodyDetail(
-                title = strings.widgets.logDetails.responseBody,
-                body = logDetail.responseBody
-            )
+        when (state.selectedTab) {
+            Tab.Response -> {
+                SectionTitle(label = strings.widgets.logDetails.responseHeaders)
+                HeadersContent(logDetail.responseHeaders.toList(), strings)
+                Spacer(Modifier.height(8.dp))
+                SectionTitle(label = strings.widgets.logDetails.responseBody)
+                BodyContent(logDetail.responseBody, strings)
+            }
+            Tab.Request -> {
+                SectionTitle(label = strings.widgets.logDetails.requestHeaders)
+                HeadersContent(logDetail.requestHeaders.toList(), strings)
+                Spacer(Modifier.height(8.dp))
+                SectionTitle(label = strings.widgets.logDetails.requestBody)
+                BodyContent(logDetail.requestBody, strings)
+            }
         }
     }
 }
 
 @Composable
-fun MonitorLogDetailsEmptyContent(
-    strings: Strings = LocalStrings.current,
-) {
+fun MonitorLogDetailsEmptyContent(strings: Strings = LocalStrings.current) {
     EmptyState(
         title = strings.widgets.logDetails.emptyTitle,
-        description = strings.widgets.logDetails.emptyDescription
-    )
-}
-
-@Preview
-@Composable
-fun MonitorLogDetailsWidgetPreview() = PreviewSurface {
-    LogDetailsContent(
-        logDetail = LogEvent(
-            timestamp = 1000,
-            url = "https://www.example.com/url",
-            requestBody = "request body",
-            requestHeaders = mapOf(),
-            responseHeaders = mapOf(),
-            responseBody = "response body",
-            status = HttpStatusCode.OK,
-            delay = 50,
-            method = "GET",
-            isIntendedFailure = false
-        ),
-        visible = MonitorLogDetailsViewModel.State.ViewDetails(
-            requestHeaders = true,
-            requestBody = true,
-            responseHeaders = true,
-            responseBody = true
-        ),
-        onViewRequestHeaders = {},
-        onViewRequestBody = {},
-        onViewResponseHeaders = {},
-        onViewResponseBody = {}
+        description = strings.widgets.logDetails.emptyDescription,
     )
 }
 
@@ -227,80 +138,276 @@ fun MonitorLogDetailsWidgetEmptyPreview() = PreviewSurface {
     }
 }
 
+@Suppress("COMPLEX_EXPRESSION", "MAGIC_NUMBER")
+@Preview
 @Composable
-private fun ViewToggleCheckbox(
-    checked: Boolean,
-    onCheckedChanged: (Boolean) -> Unit,
-    title: String,
-) {
-    Row(
+fun MonitorLogDetailsWidgetPreview() {
+    val previewBody = """{"repairs":[{"id":"HSR-9455","repairStatus":"Upcoming","faultDescription":"Boiler pilot light"}]}"""
+    val previewStatus = HttpStatusCode.OK
+    val authHeader = "Authorization" to "Bearer token123"
+    val contentTypeHeader = "Content-Type" to "application/json"
+    val previewRequestHeaders = mapOf(authHeader)
+    val previewResponseHeaders = mapOf(contentTypeHeader)
+    val previewState = ViewDetails(selectedTab = Tab.Response)
+    val previewEvent = LogEvent(
+        timestamp = 1_716_474_257_201L,
+        url = "https://api.example.com/repairs",
+        requestBody = "",
+        requestHeaders = previewRequestHeaders,
+        responseHeaders = previewResponseHeaders,
+        responseBody = previewBody,
+        status = previewStatus,
+        delay = 342,
+        method = "GET",
+        isIntendedFailure = false,
+    )
+    PreviewSurface {
+        LogDetailsContent(
+            logDetail = previewEvent,
+            state = previewState,
+            onTabSelected = {},
+        )
+    }
+}
+
+// ── Header bar ────────────────────────────────────────────────────────────────
+
+@Suppress("MAGIC_NUMBER")
+@Composable
+private fun LogHeaderBar(logDetail: LogEvent, onClose: () -> Unit) {
+    val metaColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f)
+    val monoFont = LocalMonoFontFamily.current
+
+    Column(
         modifier = Modifier
-            .minimumInteractiveComponentSize()
-            .toggleable(
-                value = checked,
-                onValueChange = onCheckedChanged,
-                role = Role.Checkbox,
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f))
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            LogStatusBadge(status = logDetail.status)
+            Text(
+                text = urlToTitle(logDetail.url),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.weight(1f),
             )
-            .padding(8.dp)
-    ) {
-        Text(text = title, modifier = Modifier.weight(1F, fill = false))
-        Spacer(modifier = Modifier.width(4.dp))
-        Checkbox(
-            checked = checked,
-            onCheckedChange = null,
-        )
-    }
-}
-
-@Composable
-private fun BodyDetail(
-    title: String,
-    body: String,
-    strings: Strings = LocalStrings.current,
-) {
-    Column(
-        modifier = Modifier.padding(vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp)
-    ) {
-        Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium
-        )
-        SelectionContainer {
-            Text(text = body, fontFamily = FontFamily.Monospace)
+            Text(
+                text = "×",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .clickable(onClick = onClose)
+                    .padding(4.dp),
+            )
         }
-        if (body.isEmpty()) {
-            Text(text = strings.widgets.logDetails.noBody)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            MetaItem(icon = "⏱", label = "${logDetail.delay}ms", color = metaColor)
+            MetaItem(icon = "↑", label = logDetail.requestBody.toKbLabel(), color = metaColor)
+            MetaItem(icon = "↓", label = logDetail.responseBody.toKbLabel(), color = metaColor)
+            Text(
+                text = formatTimestamp(logDetail.timestamp),
+                style = MaterialTheme.typography.labelMedium.copy(fontFamily = monoFont),
+                color = metaColor,
+            )
         }
     }
 }
 
+@Suppress("MAGIC_NUMBER")
 @Composable
-private fun HeaderDetail(
-    title: String,
-    headers: List<Pair<String, String>>,
-    strings: Strings = LocalStrings.current,
+private fun LogStatusBadge(status: HttpStatusCode) {
+    val monoFont = LocalMonoFontFamily.current
+    val cs = MaterialTheme.colorScheme
+    val statusClass = status.value / 100
+    val statusColor = when (statusClass) {
+        2 -> cs.success.primary
+        3 -> cs.warning.primary
+        else -> cs.error
+    }
+    Text(
+        text = status.value.toString(),
+        modifier = Modifier
+            .border(width = 1.5.dp, color = statusColor, shape = RoundedCornerShape(percent = 50))
+            .padding(horizontal = 8.dp, vertical = 3.dp),
+        style = MaterialTheme.typography.labelMedium.copy(fontFamily = monoFont),
+        color = statusColor,
+        fontWeight = FontWeight.Bold,
+    )
+}
+
+@Composable
+private fun MetaItem(
+    icon: String,
+    label: String,
+    color: Color
 ) {
-    Column(
-        modifier = Modifier.padding(vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp)
+    val monoFont = LocalMonoFontFamily.current
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
     ) {
         Text(
-            text = title,
-            style = MaterialTheme.typography.titleMedium
+            text = icon,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
         )
-        SelectionContainer {
-            Column {
-                headers.forEach { (key, value) ->
-                    Text(
-                        text = "$key: $value",
-                        fontFamily = FontFamily.Monospace
-                    )
-                }
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelMedium.copy(fontFamily = monoFont),
+            color = color,
+        )
+    }
+}
+
+// ── Tab bar ───────────────────────────────────────────────────────────────────
+
+@Suppress("MAGIC_NUMBER")
+@Composable
+private fun LogTabBar(selectedTab: Tab, onTabSelected: (Tab) -> Unit) {
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Tab.entries.forEach { tab ->
+            val isSelected = tab == selectedTab
+            val selectedColor = if (isSelected) {
+                MaterialTheme.colorScheme.primary
+            } else {
+                MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+            }
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { onTabSelected(tab) },
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = tab.name,
+                    modifier = Modifier.padding(vertical = 10.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+                    color = selectedColor,
+                )
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(2.dp)
+                        .background(
+                            if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
+                        ),
+                )
             }
         }
-        if (headers.isEmpty()) {
-            Text(text = strings.widgets.logDetails.noHeaders)
+    }
+}
+
+// ── Content sections ──────────────────────────────────────────────────────────
+
+@Suppress("MAGIC_NUMBER")
+@Composable
+private fun BodyContent(body: String, strings: Strings) {
+    val monoFont = LocalMonoFontFamily.current
+    if (body.isEmpty()) {
+        Text(
+            text = strings.widgets.logDetails.noBody,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+            modifier = Modifier.padding(vertical = 4.dp),
+        )
+        return
+    }
+    val cs = MaterialTheme.colorScheme
+    val jsonColors = JsonHighlightColors(
+        keyColor = cs.jsonKey,
+        stringColor = cs.success.primary,
+        numberColor = cs.tertiary,
+        boolColor = cs.warning.primary,
+        nullColor = cs.onSurface.copy(alpha = ALPHA_MUTED),
+    )
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = cs.onSurface.copy(alpha = 0.06f),
+                shape = RoundedCornerShape(6.dp),
+            )
+            .padding(10.dp),
+    ) {
+        SelectionContainer {
+            Text(
+                text = buildJsonAnnotatedString(body, jsonColors),
+                style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
+            )
         }
+    }
+}
+
+@Suppress("MAGIC_NUMBER")
+@Composable
+private fun HeadersContent(headers: List<Pair<String, String>>, strings: Strings) {
+    val monoFont = LocalMonoFontFamily.current
+    if (headers.isEmpty()) {
+        Text(
+            text = strings.widgets.logDetails.noHeaders,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+            modifier = Modifier.padding(vertical = 4.dp),
+        )
+        return
+    }
+    val dividerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f)
+    SelectionContainer {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            headers.forEach { (key, value) ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = key,
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
+                        color = MaterialTheme.colorScheme.tertiary,
+                        modifier = Modifier.weight(0.4f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = value,
+                        style = MaterialTheme.typography.bodySmall.copy(fontFamily = monoFont),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.weight(0.6f),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                DashedDivider(color = dividerColor)
+            }
+        }
+    }
+}
+
+@Suppress("MAGIC_NUMBER")
+@Composable
+private fun DashedDivider(color: Color) {
+    Canvas(modifier = Modifier.fillMaxWidth().height(1.dp)) {
+        drawLine(
+            color = color,
+            start = androidx.compose.ui.geometry.Offset(0f, 0f),
+            end = androidx.compose.ui.geometry.Offset(size.width, 0f),
+            strokeWidth = 1.dp.toPx(),
+            cap = StrokeCap.Round,
+            pathEffect = PathEffect.dashPathEffect(
+                intervals = floatArrayOf(4.dp.toPx(), 4.dp.toPx()),
+                phase = 0f,
+            ),
+        )
     }
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/monitorlogs/details/MonitorLogDetailsFormattersTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/monitorlogs/details/MonitorLogDetailsFormattersTests.kt
@@ -91,19 +91,18 @@ class MonitorLogDetailsFormattersTests {
 
     @Test
     fun `prettyPrintJson formats a flat object`() {
-        val input = """{"name":"John","age":30}"""
         val expected = """
             {
               "name": "John",
               "age": 30
             }
         """.trimIndent()
+        val input = """{"name":"John","age":30}"""
         assertEquals(expected, input.prettyPrintJson())
     }
 
     @Test
     fun `prettyPrintJson formats a nested object`() {
-        val input = """{"a":{"b":"c"}}"""
         val expected = """
             {
               "a": {
@@ -111,12 +110,12 @@ class MonitorLogDetailsFormattersTests {
               }
             }
         """.trimIndent()
+        val input = """{"a":{"b":"c"}}"""
         assertEquals(expected, input.prettyPrintJson())
     }
 
     @Test
     fun `prettyPrintJson formats an array`() {
-        val input = """[1,2,3]"""
         val expected = """
             [
               1,
@@ -124,14 +123,14 @@ class MonitorLogDetailsFormattersTests {
               3
             ]
         """.trimIndent()
+        val input = """[1,2,3]"""
         assertEquals(expected, input.prettyPrintJson())
     }
 
     @Test
     fun `prettyPrintJson preserves escaped quotes inside strings`() {
-        val input = """{"msg":"hello \"world\""}"""
         assertTrue(
-            input.prettyPrintJson().contains(""""hello \"world\"""""),
+            """{"msg":"hello \"world\""}""".prettyPrintJson().contains(""""hello \"world\"""""),
             "Expected escaped quotes to be preserved in output"
         )
     }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/monitorlogs/details/MonitorLogDetailsFormattersTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/monitorlogs/details/MonitorLogDetailsFormattersTests.kt
@@ -1,0 +1,218 @@
+package com.apadmi.mockzilla.ui.ui.widgets.monitorlogs.details
+
+import androidx.compose.ui.graphics.Color
+
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.JsonHighlightColors
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.buildJsonAnnotatedString
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.formatTimestamp
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.prettyPrintJson
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.toKbLabel
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.urlToTitle
+
+import org.junit.Test
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MonitorLogDetailsFormattersTests {
+
+    // ── toKbLabel ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `toKbLabel returns zero for empty string`() {
+        assertEquals("0.0 KB", "".toKbLabel())
+    }
+
+    @Test
+    fun `toKbLabel returns half a kilobyte for 512 bytes`() {
+        assertEquals("0.5 KB", "a".repeat(512).toKbLabel())
+    }
+
+    @Test
+    fun `toKbLabel returns 1 point 0 for exactly 1024 bytes`() {
+        assertEquals("1.0 KB", "a".repeat(1024).toKbLabel())
+    }
+
+    // ── urlToTitle ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `urlToTitle capitalises last path segment`() {
+        assertEquals("Repairs", urlToTitle("https://api.example.com/repairs"))
+    }
+
+    @Test
+    fun `urlToTitle strips trailing slash before extracting segment`() {
+        assertEquals("Repairs", urlToTitle("https://api.example.com/repairs/"))
+    }
+
+    @Test
+    fun `urlToTitle strips query parameters from the segment`() {
+        assertEquals("Repairs", urlToTitle("https://api.example.com/repairs?status=upcoming"))
+    }
+
+    @Test
+    fun `urlToTitle uses hostname when url has no path segment`() {
+        // substringAfterLast('/') on "https://api.example.com" returns "api.example.com"
+        // (the last '/' is the one in "https://"), so the hostname is used and capitalised.
+        assertEquals("Api.example.com", urlToTitle("https://api.example.com"))
+    }
+
+    @Test
+    fun `urlToTitle falls back to full url when result would be blank`() {
+        // "/" → trimEnd('/') → "" → substringAfterLast('/') → "" → replaceFirstChar → ""
+        // ifBlank returns the original url.
+        assertEquals("/", urlToTitle("/"))
+    }
+
+    // ── formatTimestamp ───────────────────────────────────────────────────────
+
+    @Test
+    fun `formatTimestamp always emits 3 millisecond digits for whole seconds`() {
+        // secondFraction(3) pads with trailing zeros, so 00:00:01 becomes 00:00:01.000
+        assertEquals("00:00:01.000", formatTimestamp(1_000L))
+    }
+
+    @Test
+    fun `formatTimestamp formats sub-second precision correctly`() {
+        assertEquals("00:00:01.500", formatTimestamp(1_500L))
+    }
+
+    @Test
+    fun `formatTimestamp formats single millisecond correctly`() {
+        assertEquals("00:00:00.001", formatTimestamp(1L))
+    }
+
+    // ── prettyPrintJson ───────────────────────────────────────────────────────
+
+    @Test
+    fun `prettyPrintJson returns non-json input unchanged`() {
+        assertEquals("hello world", "hello world".prettyPrintJson())
+    }
+
+    @Test
+    fun `prettyPrintJson formats a flat object`() {
+        val input = """{"name":"John","age":30}"""
+        val expected = """
+            {
+              "name": "John",
+              "age": 30
+            }
+        """.trimIndent()
+        assertEquals(expected, input.prettyPrintJson())
+    }
+
+    @Test
+    fun `prettyPrintJson formats a nested object`() {
+        val input = """{"a":{"b":"c"}}"""
+        val expected = """
+            {
+              "a": {
+                "b": "c"
+              }
+            }
+        """.trimIndent()
+        assertEquals(expected, input.prettyPrintJson())
+    }
+
+    @Test
+    fun `prettyPrintJson formats an array`() {
+        val input = """[1,2,3]"""
+        val expected = """
+            [
+              1,
+              2,
+              3
+            ]
+        """.trimIndent()
+        assertEquals(expected, input.prettyPrintJson())
+    }
+
+    @Test
+    fun `prettyPrintJson preserves escaped quotes inside strings`() {
+        val input = """{"msg":"hello \"world\""}"""
+        assertTrue(
+            input.prettyPrintJson().contains(""""hello \"world\"""""),
+            "Expected escaped quotes to be preserved in output"
+        )
+    }
+
+    @Test
+    fun `prettyPrintJson strips insignificant whitespace`() {
+        val withSpaces = """{ "key" : "value" }"""
+        val compact = """{"key":"value"}"""
+        assertEquals(compact.prettyPrintJson(), withSpaces.prettyPrintJson())
+    }
+
+    // ── buildJsonAnnotatedString ──────────────────────────────────────────────
+
+    private val colors = JsonHighlightColors(
+        keyColor = Color.Blue,
+        stringColor = Color.Green,
+        numberColor = Color.Yellow,
+        boolColor = Color.Magenta,
+        nullColor = Color.Gray,
+    )
+
+    @Test
+    fun `buildJsonAnnotatedString plain text equals pretty printed json`() {
+        val json = """{"key":"value"}"""
+        assertEquals(json.prettyPrintJson(), buildJsonAnnotatedString(json, colors).text)
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString returns unstyled text for non-json input`() {
+        val plain = "not json at all"
+        val result = buildJsonAnnotatedString(plain, colors)
+        assertEquals(plain, result.text)
+        assertTrue(result.spanStyles.isEmpty(), "Expected no spans for plain text")
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString colours object keys with keyColor`() {
+        val result = buildJsonAnnotatedString("""{"name":"John"}""", colors)
+        val span = result.spanStyles.first { it.item.color == Color.Blue }
+        assertEquals(""""name"""", result.text.substring(span.start, span.end))
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString colours string values with stringColor`() {
+        val result = buildJsonAnnotatedString("""{"name":"John"}""", colors)
+        val span = result.spanStyles.first { it.item.color == Color.Green }
+        assertEquals(""""John"""", result.text.substring(span.start, span.end))
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString colours integer numbers with numberColor`() {
+        val result = buildJsonAnnotatedString("""{"age":30}""", colors)
+        val span = result.spanStyles.first { it.item.color == Color.Yellow }
+        assertEquals("30", result.text.substring(span.start, span.end))
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString colours negative numbers with numberColor`() {
+        val result = buildJsonAnnotatedString("""{"temp":-5}""", colors)
+        val span = result.spanStyles.first { it.item.color == Color.Yellow }
+        assertEquals("-5", result.text.substring(span.start, span.end))
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString colours true with boolColor`() {
+        val result = buildJsonAnnotatedString("""{"active":true}""", colors)
+        val span = result.spanStyles.first { it.item.color == Color.Magenta }
+        assertEquals("true", result.text.substring(span.start, span.end))
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString colours false with boolColor`() {
+        val result = buildJsonAnnotatedString("""{"active":false}""", colors)
+        val span = result.spanStyles.first { it.item.color == Color.Magenta }
+        assertEquals("false", result.text.substring(span.start, span.end))
+    }
+
+    @Test
+    fun `buildJsonAnnotatedString colours null with nullColor`() {
+        val result = buildJsonAnnotatedString("""{"value":null}""", colors)
+        val span = result.spanStyles.first { it.item.color == Color.Gray }
+        assertEquals("null", result.text.substring(span.start, span.end))
+    }
+}

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/monitorlogs/details/MonitorLogDetailsViewModelTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/monitorlogs/details/MonitorLogDetailsViewModelTests.kt
@@ -2,6 +2,7 @@ package com.apadmi.mockzilla.ui.ui.widgets.monitorlogs.details
 
 import com.apadmi.mockzilla.testutils.CoroutineTest
 import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.MonitorLogDetailsViewModel
+import com.apadmi.mockzilla.ui.ui.common.widgets.monitorlogs.details.MonitorLogDetailsViewModel.State.ViewDetails.Tab
 
 import app.cash.turbine.test
 import org.junit.Test
@@ -11,64 +12,40 @@ import kotlin.test.assertEquals
 class MonitorLogDetailsViewModelTests : CoroutineTest() {
     private fun createSut() = MonitorLogDetailsViewModel(testScope.backgroundScope)
 
-    @Suppress("TOO_LONG_FUNCTION")
     @Test
-    fun `onView methods update the state`() = runBlockingTest {
+    fun `default state has Response tab selected`() = runBlockingTest {
+        /* Setup */
+        val sut = createSut()
+
+        /* Verify */
+        assertEquals(
+            MonitorLogDetailsViewModel.State.ViewDetails(selectedTab = Tab.Response),
+            sut.state.value,
+        )
+    }
+
+    @Test
+    fun `onTabSelected updates the selected tab`() = runBlockingTest {
         /* Setup */
         val sut = createSut()
 
         /* Run Test */
         sut.state.test {
-            sut.onViewRequestBody(true)
-            sut.onViewRequestHeaders(true)
-            sut.onViewResponseHeaders(true)
-            sut.onViewResponseBody(false)
+            awaitItem() // consume initial state
+
+            sut.onTabSelected(Tab.Request)
 
             /* Verify */
             assertEquals(
-                MonitorLogDetailsViewModel.State.ViewDetails(
-                    requestHeaders = false,
-                    requestBody = false,
-                    responseHeaders = false,
-                    responseBody = true,
-                ),
-                awaitItem()
+                MonitorLogDetailsViewModel.State.ViewDetails(selectedTab = Tab.Request),
+                awaitItem(),
             )
+
+            sut.onTabSelected(Tab.Response)
+
             assertEquals(
-                MonitorLogDetailsViewModel.State.ViewDetails(
-                    requestHeaders = false,
-                    requestBody = true,
-                    responseHeaders = false,
-                    responseBody = true,
-                ),
-                awaitItem()
-            )
-            assertEquals(
-                MonitorLogDetailsViewModel.State.ViewDetails(
-                    requestHeaders = true,
-                    requestBody = true,
-                    responseHeaders = false,
-                    responseBody = true,
-                ),
-                awaitItem()
-            )
-            assertEquals(
-                MonitorLogDetailsViewModel.State.ViewDetails(
-                    requestHeaders = true,
-                    requestBody = true,
-                    responseHeaders = true,
-                    responseBody = true,
-                ),
-                awaitItem()
-            )
-            assertEquals(
-                MonitorLogDetailsViewModel.State.ViewDetails(
-                    requestHeaders = true,
-                    requestBody = true,
-                    responseHeaders = true,
-                    responseBody = false,
-                ),
-                awaitItem()
+                MonitorLogDetailsViewModel.State.ViewDetails(selectedTab = Tab.Response),
+                awaitItem(),
             )
         }
     }


### PR DESCRIPTION
** Implements the monitor logs feature end-to-end across two widgets:**

- MonitorLogsWidget — a collapsible bottom panel that streams live HTTP traffic from the connected device. Consumes MonitorLogsViewModel state and renders a lazy list of log entries with auto-scroll behaviour that preserves user scroll position when they are not at the bottom.

- MonitorLogDetailsWidget — a detail panel driven by MonitorLogDetailsViewModel that renders the full request/response breakdown for a selected LogEvent. State is shared via the existing AppRootViewModel selected-log mechanism and wired through DesktopAppRoot right-panel widgets.

- Non-UI logic is separated into MonitorLogDetailsFormatters.kt following the existing endpoints/details/ convention (JsonTokens.kt pattern), keeping the widget file pure Compose. Formatting includes a KMP-compatible JSON pretty-printer and syntax annotator (no String.format or platform APIs).

- A new jsonKey semantic colour token is introduced in the design system to distinguish JSON key colour from the existing tertiary token used elsewhere.

** Architecture decisions**
- MonitorLogDetailsFormatters.kt placed alongside the widget in details/ — consistent with how EndpointBodyVisualTransformation.kt and JsonTokens.kt are co-located with their feature widgets
- buildJsonAnnotatedString accepts JsonHighlightColors as a plain data class so the function is pure and testable without a Compose context
- Auto-scroll uses LazyListState.layoutInfo to check whether the user was already at the bottom before deciding to scroll, avoiding forced jumps mid-browsing