### PR TITLE
refactor(endpoints-widget): redesign endpoints list UI with selection, hover, and responsive layout

### DIFF
--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
@@ -111,7 +111,9 @@ val EnStrings = Strings(
                     1 -> "1 override:"
                     else -> "$number overrides:"
                 }
-            }
+            },
+            noOverrides = "no overrides",
+            forced = "FORCED",
         ),
         globalControls = Strings.Widgets.GlobalControls(
             title = "Global Controls",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
@@ -261,11 +261,15 @@ data class Strings(
          * @property filterPlaceholder
          * @property numberOfEndpointsShown
          * @property overrides
+         * @property noOverrides
+         * @property forced
          */
         data class Endpoints(
             val filterPlaceholder: String,
             val numberOfEndpointsShown: (shown: Int, max: Int) -> String,
-            val overrides: (number: Int) -> String
+            val overrides: (number: Int) -> String,
+            val noOverrides: String,
+            val forced: String,
         )
 
         /**

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/StatusChip.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/StatusChip.kt
@@ -1,5 +1,6 @@
 package com.apadmi.mockzilla.ui.ui.common.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -22,7 +23,7 @@ import com.apadmi.mockzilla.ui.ui.common.theme.warning
 import org.jetbrains.compose.ui.tooling.preview.Preview
 
 enum class ChipTone {
-    Accent, Err, Info, Neutral, Ok, Warn
+    Accent, Err, Info, Neutral, Ok, Teal, Warn
 }
 
 /**
@@ -49,6 +50,7 @@ fun StatusChip(
     Text(
         text = label,
         modifier = modifier
+            .background(colors.background, RoundedCornerShape(3.dp))
             .border(width = 1.dp, color = colors.border, shape = RoundedCornerShape(3.dp))
             .padding(horizontal = 4.dp, vertical = 1.dp),
         style = MaterialTheme.typography.labelSmall.copy(
@@ -78,6 +80,10 @@ private fun chipColors(tone: ChipTone): ChipColors {
             text = cs.error,
             background = cs.errorContainer,
         )
+        ChipTone.Teal -> {
+            val color = cs.primary
+            ChipColors(border = color, text = color, background = color.copy(alpha = 0.14f))
+        }
         ChipTone.Accent -> ChipColors(
             border = cs.primary,
             text = cs.primary,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Color.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Color.kt
@@ -30,7 +30,7 @@ val darkPrimaryContainer = darkPrimary.copy(alpha = 0.14f)
 
 val darkSuccess = Color(0xFF4ADE80)
 val darkSuccessContainer = darkSuccess.copy(alpha = 0.14f)
-val darkWarning = Color(0xFFFACC15)
+val darkWarning = Color(0xFFCCB125)
 val darkWarningContainer = darkWarning.copy(alpha = 0.14f)
 val darkError = Color(0xFFF87171)
 val darkErrorContainer = darkError.copy(alpha = 0.14f)

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Theme.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Theme.kt
@@ -96,6 +96,10 @@ private val lightColors = lightColorScheme(
 // ── Extensions for colours that don't map onto a Material slot ────────────────
 
 @get:Composable
+val ColorScheme.inputBackground: Color
+    get() = if (LocalForceDarkMode.current || isSystemInDarkTheme()) darkSurfaceContainer else lightSurfaceVariant
+
+@get:Composable
 val ColorScheme.surfaceMuted: Color
     get() = if (LocalForceDarkMode.current || isSystemInDarkTheme()) darkSurfaceMuted else lightSurfaceMuted
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
@@ -37,17 +37,18 @@ class EndpointsViewModel(
         state.value = endpointsService.fetchAllEndpointConfigs(device).fold(
             onSuccess = { list ->
                 val currentState = state.value as? State.EndpointsList
-                val filter = currentState?.filter ?: ""
                 State.EndpointsList(
                     allEndpoints = list.map {
                         State.EndpointConfig(
                             key = it.key,
                             name = it.name,
                             fail = it.shouldFail == true,
-                            overriddenProperties = it.getOverriddenProperties()
+                            overriddenProperties = it.getOverriddenProperties(),
+                            delayMs = it.delayMs,
                         )
                     },
-                    filter
+                    filter = currentState?.filter ?: "",
+                    density = currentState?.density ?: Density.Comfy,
                 )
             },
             onFailure = {
@@ -59,10 +60,12 @@ class EndpointsViewModel(
 
     fun onFilterChanged(value: String) {
         val currentState = state.value as? State.EndpointsList ?: return
+        state.value = currentState.copy(filter = value)
+    }
 
-        state.value = currentState.copy(
-            filter = value
-        )
+    fun onDensityChanged(density: Density) {
+        val currentState = state.value as? State.EndpointsList ?: return
+        state.value = currentState.copy(density = density)
     }
 
     sealed class State {
@@ -73,21 +76,25 @@ class EndpointsViewModel(
          * @property name
          * @property fail
          * @property overriddenProperties
+         * @property delayMs Overridden delay in milliseconds, or null if not overridden.
          */
         data class EndpointConfig(
             val key: EndpointConfiguration.Key,
             val name: String,
             val fail: Boolean,
             val overriddenProperties: List<EndpointProperties>,
+            val delayMs: Int?,
         )
 
         /**
          * @property allEndpoints Endpoints list before applying the filter string
          * @property filter Filter string
+         * @property density Display density for the list rows
          */
         data class EndpointsList(
             val allEndpoints: List<EndpointConfig>,
             val filter: String,
+            val density: Density = Density.Comfy,
         ) : State() {
             /**
              * Filtered endpoints
@@ -97,12 +104,17 @@ class EndpointsViewModel(
     }
 }
 
+/** Controls how much information each row in the endpoint list shows. */
+enum class Density {
+    Comfy, Compact
+}
+
 /**
  * @property displayName
  */
 enum class EndpointProperties(val displayName: String) {
     Body("Body"),
-    Delay("Delay"),
+    Delay("Latency"),
     Headers("Headers"),
     Status("Status"),
     ;

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsViewModel.kt
@@ -48,7 +48,7 @@ class EndpointsViewModel(
                         )
                     },
                     filter = currentState?.filter ?: "",
-                    density = currentState?.density ?: Density.Comfy,
+                    rowDensity = currentState?.rowDensity ?: RowDensity.Comfy,
                 )
             },
             onFailure = {
@@ -63,9 +63,9 @@ class EndpointsViewModel(
         state.value = currentState.copy(filter = value)
     }
 
-    fun onDensityChanged(density: Density) {
+    fun onRowDensityChanged(rowDensity: RowDensity) {
         val currentState = state.value as? State.EndpointsList ?: return
-        state.value = currentState.copy(density = density)
+        state.value = currentState.copy(rowDensity = rowDensity)
     }
 
     sealed class State {
@@ -89,12 +89,12 @@ class EndpointsViewModel(
         /**
          * @property allEndpoints Endpoints list before applying the filter string
          * @property filter Filter string
-         * @property density Display density for the list rows
+         * @property rowDensity Display density for the list rows
          */
         data class EndpointsList(
             val allEndpoints: List<EndpointConfig>,
             val filter: String,
-            val density: Density = Density.Comfy,
+            val rowDensity: RowDensity = RowDensity.Comfy,
         ) : State() {
             /**
              * Filtered endpoints
@@ -105,7 +105,7 @@ class EndpointsViewModel(
 }
 
 /** Controls how much information each row in the endpoint list shows. */
-enum class Density {
+enum class RowDensity {
     Comfy, Compact
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -71,8 +71,7 @@ private const val UNSELECTED_BORDER_ALPHA = 0.2f
 private const val LEFT_BORDER_WIDTH_DP = 3
 private const val CONTENT_START_PADDING_DP = 13
 private const val COMPACT_VERTICAL_PADDING_DP = 10
-private const val COZY_VERTICAL_PADDING_DP = 14
-private const val COMFY_VERTICAL_PADDING_DP = 18
+private const val COMFY_VERTICAL_PADDING_DP = 14
 private const val DELAY_TENTHS_DIVISOR = 100
 private const val DELAY_TENTHS_MODULO = 10
 
@@ -83,7 +82,7 @@ private fun EndpointProperties.chipTone(): ChipTone = when (this) {
 
 private fun Density.verticalPadding(): Dp = when (this) {
     Density.Compact -> COMPACT_VERTICAL_PADDING_DP.dp
-    Density.Comfy -> COZY_VERTICAL_PADDING_DP.dp
+    Density.Comfy -> COMFY_VERTICAL_PADDING_DP.dp
 }
 
 @Composable
@@ -217,8 +216,11 @@ private fun EndpointRow(
             .fillMaxWidth()
             .hoverable(interactionSource = interactionSource)
             .background(
-                if (isSelected || isHovered) cs.onSurface.copy(alpha = HOVER_ALPHA)
-                else Color.Transparent
+                if (isSelected || isHovered) {
+                    cs.onSurface.copy(alpha = HOVER_ALPHA)
+                } else {
+                    Color.Transparent
+                }
             )
             .drawBehind {
                 drawRect(
@@ -243,15 +245,15 @@ private fun EndpointRow(
                 EndpointRowChips(endpoint = endpoint)
             }
         }
+        if (endpoint.fail) {
+            StatusChip(label = strings.widgets.endpoints.forced, tone = ChipTone.Err)
+        }
         endpoint.delayMs?.let { delay ->
             Text(
                 text = formatDelaySeconds(delay),
                 style = MaterialTheme.typography.labelSmall,
                 color = cs.warning.primary,
             )
-        }
-        if (endpoint.fail) {
-            StatusChip(label = strings.widgets.endpoints.forced, tone = ChipTone.Err)
         }
         Icon(
             imageVector = Icons.Default.ChevronRight,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -3,17 +3,24 @@ package com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -32,6 +39,9 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
@@ -50,12 +60,12 @@ import com.apadmi.mockzilla.ui.i18n.Strings
 import com.apadmi.mockzilla.ui.ui.common.components.ChipTone
 import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
 import com.apadmi.mockzilla.ui.ui.common.components.StatusChip
-import com.apadmi.mockzilla.ui.ui.common.theme.inputBackground
 import com.apadmi.mockzilla.ui.ui.common.theme.warning
 
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
+private const val MIN_CONTENT_WIDTH_DP = 300
 private const val HOVER_ALPHA = 0.08f
 private const val UNSELECTED_BORDER_ALPHA = 0.2f
 private const val LEFT_BORDER_WIDTH_DP = 3
@@ -86,12 +96,17 @@ fun EndpointsWidget(
         parametersOf(device)
     }
     val state by viewModel.state.collectAsState()
+    var selectedKey by remember { mutableStateOf<Key?>(null) }
 
     EndpointsWidgetContent(
         state = state,
+        selectedKey = selectedKey,
         onFilterUpdate = viewModel::onFilterChanged,
         onDensityChanged = viewModel::onDensityChanged,
-        onEndpointClicked = onEndpointClicked,
+        onEndpointClicked = { key ->
+            selectedKey = key
+            onEndpointClicked(key)
+        },
         onGlobalControlsClicked = onGlobalControlsClicked
     )
 }
@@ -104,6 +119,7 @@ private fun formatDelaySeconds(delayMs: Int): String {
 @Composable
 private fun EndpointsList(
     state: EndpointsViewModel.State.EndpointsList,
+    selectedKey: Key?,
     onEndpointClicked: (Key) -> Unit,
     onFilterUpdate: (String) -> Unit,
     onDensityChanged: (Density) -> Unit,
@@ -120,6 +136,7 @@ private fun EndpointsList(
         EndpointRow(
             endpoint = endpoint,
             density = state.density,
+            isSelected = endpoint.key == selectedKey,
             onEndpointClicked = onEndpointClicked,
         )
     }
@@ -181,19 +198,28 @@ private fun DensityButton(
 private fun EndpointRow(
     endpoint: EndpointsViewModel.State.EndpointConfig,
     density: Density,
+    isSelected: Boolean,
     onEndpointClicked: (Key) -> Unit,
     strings: Strings = LocalStrings.current,
 ) {
     val cs = MaterialTheme.colorScheme
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
     val leftBorderColor = when {
         endpoint.fail -> cs.error
         endpoint.overriddenProperties.any { it != EndpointProperties.Delay } -> cs.primary
         endpoint.overriddenProperties.isNotEmpty() -> cs.warning.primary
+        isSelected -> cs.primary
         else -> Color.Transparent
     }
     Row(
         modifier = Modifier
             .fillMaxWidth()
+            .hoverable(interactionSource = interactionSource)
+            .background(
+                if (isSelected || isHovered) cs.onSurface.copy(alpha = HOVER_ALPHA)
+                else Color.Transparent
+            )
             .drawBehind {
                 drawRect(
                     leftBorderColor,
@@ -208,6 +234,7 @@ private fun EndpointRow(
                 bottom = density.verticalPadding(),
             ),
         verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Column(modifier = Modifier.weight(1f)) {
             EndpointRowMainContent(endpoint = endpoint)
@@ -276,40 +303,53 @@ private fun EndpointRowChips(
 @Composable
 private fun EndpointsWidgetContent(
     state: EndpointsViewModel.State,
+    selectedKey: Key?,
     onFilterUpdate: (String) -> Unit,
     onDensityChanged: (Density) -> Unit,
     onEndpointClicked: (Key) -> Unit,
     onGlobalControlsClicked: () -> Unit,
     strings: Strings = LocalStrings.current
-) = Box(
-    modifier = Modifier
-        .fillMaxSize()
-        .background(color = MaterialTheme.colorScheme.background)
-        .padding(horizontal = 12.dp, vertical = 15.dp)
-        .navigationBarsPadding()
 ) {
-    when (state) {
-        EndpointsViewModel.State.Loading -> CircularProgressIndicator()
-        is EndpointsViewModel.State.EndpointsList -> {
-            EndpointsList(
-                state = state,
-                onEndpointClicked = onEndpointClicked,
-                onFilterUpdate = onFilterUpdate,
-                onDensityChanged = onDensityChanged,
-            )
-            FloatingActionButton(
-                modifier = Modifier
-                    .padding(end = 8.dp)
-                    .align(Alignment.BottomEnd)
-                    .zIndex(1f),
-                onClick = onGlobalControlsClicked,
-                containerColor = MaterialTheme.colorScheme.primary,
-                contentColor = MaterialTheme.colorScheme.onPrimary
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Settings,
-                    contentDescription = strings.widgets.globalControls.title
-                )
+    val horizontalScrollState = rememberScrollState()
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = MaterialTheme.colorScheme.background)
+    ) {
+        val contentWidth = maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp)
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .horizontalScroll(horizontalScrollState)
+                .width(contentWidth)
+                .padding(horizontal = 12.dp, vertical = 15.dp)
+                .navigationBarsPadding()
+        ) {
+            when (state) {
+                EndpointsViewModel.State.Loading -> CircularProgressIndicator()
+                is EndpointsViewModel.State.EndpointsList -> {
+                    EndpointsList(
+                        state = state,
+                        selectedKey = selectedKey,
+                        onEndpointClicked = onEndpointClicked,
+                        onFilterUpdate = onFilterUpdate,
+                        onDensityChanged = onDensityChanged,
+                    )
+                    FloatingActionButton(
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .align(Alignment.BottomEnd)
+                            .zIndex(1f),
+                        onClick = onGlobalControlsClicked,
+                        containerColor = MaterialTheme.colorScheme.primary,
+                        contentColor = MaterialTheme.colorScheme.onPrimary
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = strings.widgets.globalControls.title
+                        )
+                    }
+                }
             }
         }
     }
@@ -324,25 +364,34 @@ private fun FilterTextField(
     modifier = Modifier
         .fillMaxWidth()
         .height(48.dp)
-        .background(MaterialTheme.colorScheme.surfaceContainer)
         .border(
             1.dp,
-            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
-            RoundedCornerShape(12.dp)
+            MaterialTheme.colorScheme.onBackground.copy(alpha = UNSELECTED_BORDER_ALPHA),
+            RoundedCornerShape(8.dp)
         ),
     value = value,
     onValueChange = onFilterUpdate,
-    textStyle = MaterialTheme.typography.titleMedium,
-    placeholder = { Text(strings.widgets.endpoints.filterPlaceholder) },
+    textStyle = MaterialTheme.typography.bodyLarge,
+    placeholder = {
+        Text(
+            text = strings.widgets.endpoints.filterPlaceholder,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    },
     leadingIcon = {
-        Icon(imageVector = Icons.Default.Search, contentDescription = null)
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     },
     singleLine = true,
-    shape = RoundedCornerShape(12.dp),
+    shape = RoundedCornerShape(8.dp),
     colors = TextFieldDefaults.colors().copy(
-        focusedContainerColor = MaterialTheme.colorScheme.inputBackground,
-        unfocusedContainerColor = MaterialTheme.colorScheme.inputBackground,
-        disabledContainerColor = MaterialTheme.colorScheme.inputBackground,
+        focusedContainerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
+        unfocusedContainerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
+        disabledContainerColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
         focusedIndicatorColor = Color.Transparent,
         unfocusedIndicatorColor = Color.Transparent,
         disabledIndicatorColor = Color.Transparent,
@@ -351,8 +400,9 @@ private fun FilterTextField(
 
 @Preview
 @Composable
-private fun EndpointsWidgetPreview() = PreviewSurface {
+private fun EndpointsWidgetPreview() = PreviewSurface(darkTheme = true) {
     EndpointsWidgetContent(
+        selectedKey = null,
         state = EndpointsViewModel.State.EndpointsList(
             allEndpoints = listOf(
                 EndpointsViewModel.State.EndpointConfig(

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -23,6 +23,7 @@ import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -33,9 +34,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 
@@ -44,11 +47,34 @@ import com.apadmi.mockzilla.ui.di.utils.getViewModel
 import com.apadmi.mockzilla.ui.engine.device.Device
 import com.apadmi.mockzilla.ui.i18n.LocalStrings
 import com.apadmi.mockzilla.ui.i18n.Strings
-import com.apadmi.mockzilla.ui.ui.common.assets.LightningBolt
+import com.apadmi.mockzilla.ui.ui.common.components.ChipTone
 import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import com.apadmi.mockzilla.ui.ui.common.components.StatusChip
+import com.apadmi.mockzilla.ui.ui.common.theme.inputBackground
+import com.apadmi.mockzilla.ui.ui.common.theme.warning
 
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
+
+private const val HOVER_ALPHA = 0.08f
+private const val UNSELECTED_BORDER_ALPHA = 0.2f
+private const val LEFT_BORDER_WIDTH_DP = 3
+private const val CONTENT_START_PADDING_DP = 13
+private const val COMPACT_VERTICAL_PADDING_DP = 10
+private const val COZY_VERTICAL_PADDING_DP = 14
+private const val COMFY_VERTICAL_PADDING_DP = 18
+private const val DELAY_TENTHS_DIVISOR = 100
+private const val DELAY_TENTHS_MODULO = 10
+
+private fun EndpointProperties.chipTone(): ChipTone = when (this) {
+    EndpointProperties.Delay -> ChipTone.Warn
+    else -> ChipTone.Teal
+}
+
+private fun Density.verticalPadding(): Dp = when (this) {
+    Density.Compact -> COMPACT_VERTICAL_PADDING_DP.dp
+    Density.Comfy -> COZY_VERTICAL_PADDING_DP.dp
+}
 
 @Composable
 fun EndpointsWidget(
@@ -64,160 +90,185 @@ fun EndpointsWidget(
     EndpointsWidgetContent(
         state = state,
         onFilterUpdate = viewModel::onFilterChanged,
+        onDensityChanged = viewModel::onDensityChanged,
         onEndpointClicked = onEndpointClicked,
         onGlobalControlsClicked = onGlobalControlsClicked
     )
 }
 
-@Suppress("MAGIC_NUMBER")
+private fun formatDelaySeconds(delayMs: Int): String {
+    val tenths = delayMs / DELAY_TENTHS_DIVISOR
+    return "${tenths / DELAY_TENTHS_MODULO}.${tenths % DELAY_TENTHS_MODULO} s"
+}
+
 @Composable
 private fun EndpointsList(
     state: EndpointsViewModel.State.EndpointsList,
     onEndpointClicked: (Key) -> Unit,
     onFilterUpdate: (String) -> Unit,
-    strings: Strings = LocalStrings.current
-) = Column(
-    modifier = Modifier.verticalScroll(rememberScrollState())
-) {
-    FilterTextField(
-        value = state.filter,
-        onFilterUpdate = onFilterUpdate
+    onDensityChanged: (Density) -> Unit,
+) = Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+    FilterTextField(value = state.filter, onFilterUpdate = onFilterUpdate)
+    EndpointsHeader(
+        displayedCount = state.endpoints.size,
+        totalCount = state.allEndpoints.size,
+        selectedDensity = state.density,
+        onDensityChanged = onDensityChanged,
     )
-
-    Spacer(modifier = Modifier.height(8.dp))
-
-    Text(
-        text = strings.widgets.endpoints.numberOfEndpointsShown(
-            state.endpoints.size,
-            state.allEndpoints.size
-        ),
-        color = MaterialTheme.colorScheme.onBackground,
-        style = MaterialTheme.typography.labelSmall
-    )
-
-    Spacer(modifier = Modifier.height(8.dp))
-
+    HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
     state.endpoints.forEach { endpoint ->
-        EndpointCard(
+        EndpointRow(
             endpoint = endpoint,
-            onEndpointClicked = onEndpointClicked
+            density = state.density,
+            onEndpointClicked = onEndpointClicked,
         )
-        Spacer(modifier = Modifier.height(8.dp))
     }
 }
 
-@Suppress("MAGIC_NUMBER")
 @Composable
-private fun EndpointCard(
-    endpoint: EndpointsViewModel.State.EndpointConfig,
-    onEndpointClicked: (Key) -> Unit,
-    strings: Strings = LocalStrings.current
-) = Column(
-    modifier = Modifier.fillMaxWidth()
+private fun EndpointsHeader(
+    displayedCount: Int,
+    totalCount: Int,
+    selectedDensity: Density,
+    onDensityChanged: (Density) -> Unit,
 ) {
-    val topSectionShape = RoundedCornerShape(10.dp, 10.dp, 0.dp, 0.dp)
-    val bottomSectionShape = RoundedCornerShape(0.dp, 0.dp, 10.dp, 10.dp)
-    val failureBorderColor = MaterialTheme.colorScheme.error
-
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
-            .clickable { onEndpointClicked(endpoint.key) }
-            .background(
-                color = if (endpoint.fail) {
-                    MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.2f)
-                } else {
-                    MaterialTheme.colorScheme.surface
-                },
-                shape = if (endpoint.overriddenProperties.isEmpty()) {
-                    RoundedCornerShape(10.dp)
-                } else {
-                    topSectionShape
-                }
-            )
-            .border(
-                width = if (endpoint.fail) (1.5).dp else (0.5).dp,
-                color = if (endpoint.fail) failureBorderColor else Color.Black.copy(alpha = 0.1f),
-                shape = if (endpoint.overriddenProperties.isEmpty() || endpoint.fail) {
-                    RoundedCornerShape(10.dp)
-                } else {
-                    topSectionShape
-                }
-            )
-            .padding(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
+            text = "$displayedCount/$totalCount",
             modifier = Modifier.weight(1f),
-            text = endpoint.name,
-            color = MaterialTheme.colorScheme.onSurface,
-            style = MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Medium)
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            if (endpoint.fail) {
-                Icon(
-                    modifier = Modifier
-                        .background(
-                            color = Color.Red,
-                            shape = RoundedCornerShape(4.dp)
-                        )
-                        .padding(horizontal = 12.dp, vertical = 2.dp),
-                    imageVector = Icons.LightningBolt,
-                    contentDescription = null,
-                    tint = Color.White
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            listOf(Density.Compact, Density.Comfy).forEach { density ->
+                DensityButton(
+                    label = density.name.lowercase(),
+                    isSelected = selectedDensity == density,
+                    onClick = { onDensityChanged(density) },
                 )
             }
-
-            Icon(
-                imageVector = Icons.Default.ChevronRight,
-                contentDescription = null,
-                tint = MaterialTheme.colorScheme.onSurface
-            )
         }
     }
+}
 
-    if (endpoint.overriddenProperties.isNotEmpty() && !endpoint.fail) {
-        FlowRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(
-                    color = MaterialTheme.colorScheme.secondaryContainer,  // TODO: Wire up correct colours
-                    shape = bottomSectionShape
-                )
-                .border(
-                    width = (0.5).dp,
-                    color = Color.Black.copy(alpha = 0.1f),
-                    shape = bottomSectionShape
-                )
-                .padding(horizontal = 16.dp, vertical = 10.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            itemVerticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = strings.widgets.endpoints.overrides(
-                    endpoint.overriddenProperties.size
-                ),
-                style = MaterialTheme.typography.labelMedium
-            )
-            endpoint.overriddenProperties.forEach { property ->
-                Text(
-                    modifier = Modifier
-                        .background(
-                            color = MaterialTheme.colorScheme.surfaceContainer,
-                            shape = RoundedCornerShape(8.dp)
-                        )
-                        .padding(horizontal = 8.dp, vertical = 2.dp),
-                    text = property.displayName,
-                    style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Medium)
+@Composable
+private fun DensityButton(
+    label: String,
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    val cs = MaterialTheme.colorScheme
+    val borderColor =
+        if (isSelected) cs.onSurface else cs.onSurface.copy(alpha = UNSELECTED_BORDER_ALPHA)
+    Text(
+        text = label,
+        modifier = Modifier
+            .border(width = 1.dp, color = borderColor, shape = RoundedCornerShape(4.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal,
+        color = if (isSelected) cs.onSurface else cs.onSurfaceVariant,
+    )
+}
+
+@Composable
+private fun EndpointRow(
+    endpoint: EndpointsViewModel.State.EndpointConfig,
+    density: Density,
+    onEndpointClicked: (Key) -> Unit,
+    strings: Strings = LocalStrings.current,
+) {
+    val cs = MaterialTheme.colorScheme
+    val leftBorderColor = when {
+        endpoint.fail -> cs.error
+        endpoint.overriddenProperties.any { it != EndpointProperties.Delay } -> cs.primary
+        endpoint.overriddenProperties.isNotEmpty() -> cs.warning.primary
+        else -> Color.Transparent
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .drawBehind {
+                drawRect(
+                    leftBorderColor,
+                    size = Size(LEFT_BORDER_WIDTH_DP.dp.toPx(), size.height)
                 )
             }
+            .clickable { onEndpointClicked(endpoint.key) }
+            .padding(
+                start = CONTENT_START_PADDING_DP.dp,
+                end = 12.dp,
+                top = density.verticalPadding(),
+                bottom = density.verticalPadding(),
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            EndpointRowMainContent(endpoint = endpoint)
+            if (density != Density.Compact) {
+                Spacer(Modifier.height(4.dp))
+                EndpointRowChips(endpoint = endpoint)
+            }
+        }
+        endpoint.delayMs?.let { delay ->
+            Text(
+                text = formatDelaySeconds(delay),
+                style = MaterialTheme.typography.labelSmall,
+                color = cs.warning.primary,
+            )
+        }
+        if (endpoint.fail) {
+            StatusChip(label = strings.widgets.endpoints.forced, tone = ChipTone.Err)
+        }
+        Icon(
+            imageVector = Icons.Default.ChevronRight,
+            contentDescription = null,
+            tint = cs.onSurface.copy(alpha = 0.4f),
+        )
+    }
+    HorizontalDivider(color = cs.onSurface.copy(alpha = 0.12f))
+}
+
+@Composable
+private fun EndpointRowMainContent(endpoint: EndpointsViewModel.State.EndpointConfig) {
+    Text(
+        text = endpoint.name,
+        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+}
+
+@Composable
+private fun EndpointRowChips(
+    endpoint: EndpointsViewModel.State.EndpointConfig,
+    strings: Strings = LocalStrings.current,
+) {
+    if (!endpoint.fail && endpoint.overriddenProperties.isEmpty()) {
+        Text(
+            text = strings.widgets.endpoints.noOverrides,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+        )
+        return
+    }
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        if (endpoint.fail) {
+            StatusChip(label = strings.widgets.endpoints.forced, tone = ChipTone.Err)
+        }
+        endpoint.overriddenProperties.forEach { property ->
+            StatusChip(
+                label = property.displayName.uppercase(),
+                tone = property.chipTone(),
+            )
         }
     }
 }
@@ -226,6 +277,7 @@ private fun EndpointCard(
 private fun EndpointsWidgetContent(
     state: EndpointsViewModel.State,
     onFilterUpdate: (String) -> Unit,
+    onDensityChanged: (Density) -> Unit,
     onEndpointClicked: (Key) -> Unit,
     onGlobalControlsClicked: () -> Unit,
     strings: Strings = LocalStrings.current
@@ -242,9 +294,9 @@ private fun EndpointsWidgetContent(
             EndpointsList(
                 state = state,
                 onEndpointClicked = onEndpointClicked,
-                onFilterUpdate = onFilterUpdate
+                onFilterUpdate = onFilterUpdate,
+                onDensityChanged = onDensityChanged,
             )
-
             FloatingActionButton(
                 modifier = Modifier
                     .padding(end = 8.dp)
@@ -269,7 +321,15 @@ private fun FilterTextField(
     onFilterUpdate: (String) -> Unit,
     strings: Strings = LocalStrings.current
 ) = TextField(
-    modifier = Modifier.fillMaxWidth(),
+    modifier = Modifier
+        .fillMaxWidth()
+        .height(48.dp)
+        .background(MaterialTheme.colorScheme.surfaceContainer)
+        .border(
+            1.dp,
+            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+            RoundedCornerShape(12.dp)
+        ),
     value = value,
     onValueChange = onFilterUpdate,
     textStyle = MaterialTheme.typography.titleMedium,
@@ -278,13 +338,14 @@ private fun FilterTextField(
         Icon(imageVector = Icons.Default.Search, contentDescription = null)
     },
     singleLine = true,
-    shape = RoundedCornerShape(8.dp),
+    shape = RoundedCornerShape(12.dp),
     colors = TextFieldDefaults.colors().copy(
-        focusedContainerColor = MaterialTheme.colorScheme.surface,
-        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-        disabledContainerColor = MaterialTheme.colorScheme.surface,
+        focusedContainerColor = MaterialTheme.colorScheme.inputBackground,
+        unfocusedContainerColor = MaterialTheme.colorScheme.inputBackground,
+        disabledContainerColor = MaterialTheme.colorScheme.inputBackground,
         focusedIndicatorColor = Color.Transparent,
-        unfocusedIndicatorColor = Color.Transparent
+        unfocusedIndicatorColor = Color.Transparent,
+        disabledIndicatorColor = Color.Transparent,
     )
 )
 
@@ -296,50 +357,41 @@ private fun EndpointsWidgetPreview() = PreviewSurface {
             allEndpoints = listOf(
                 EndpointsViewModel.State.EndpointConfig(
                     key = Key("1"),
-                    name = "FooBar",
+                    name = "Repairs",
                     fail = false,
                     overriddenProperties = listOf(
-                        EndpointProperties.Delay,
-                        EndpointProperties.Body
-                    )
+                        EndpointProperties.Body,
+                        EndpointProperties.Status
+                    ),
+                    delayMs = null,
                 ),
                 EndpointsViewModel.State.EndpointConfig(
                     key = Key("2"),
-                    name = "Foo",
-                    fail = true,
-                    overriddenProperties = emptyList()
+                    name = "Cancel Repair",
+                    fail = false,
+                    overriddenProperties = listOf(EndpointProperties.Delay),
+                    delayMs = 4900,
                 ),
                 EndpointsViewModel.State.EndpointConfig(
                     key = Key("3"),
-                    name = "FooBuzz",
+                    name = "Reschedule Repair",
                     fail = false,
-                    overriddenProperties = listOf(
-                        EndpointProperties.Status,
-                        EndpointProperties.Status,
-                        EndpointProperties.Delay,
-                        EndpointProperties.Body,
-                        EndpointProperties.Headers
-                    )
+                    overriddenProperties = emptyList(),
+                    delayMs = null,
                 ),
                 EndpointsViewModel.State.EndpointConfig(
                     key = Key("4"),
-                    name = "Foobar",
-                    fail = false,
-                    overriddenProperties = emptyList()
-                ),
-                EndpointsViewModel.State.EndpointConfig(
-                    key = Key("5"),
-                    name = "Foobuzz",
+                    name = "Auth — Token",
                     fail = true,
-                    overriddenProperties = listOf(
-                        EndpointProperties.Delay,
-                        EndpointProperties.Body
-                    )
-                )
+                    overriddenProperties = emptyList(),
+                    delayMs = null,
+                ),
             ),
-            filter = "Foo",
+            filter = "",
+            density = Density.Comfy,
         ),
         onFilterUpdate = {},
+        onDensityChanged = {},
         onEndpointClicked = {},
         onGlobalControlsClicked = {}
     )

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -80,9 +80,9 @@ private fun EndpointProperties.chipTone(): ChipTone = when (this) {
     else -> ChipTone.Teal
 }
 
-private fun Density.verticalPadding(): Dp = when (this) {
-    Density.Compact -> COMPACT_VERTICAL_PADDING_DP.dp
-    Density.Comfy -> COMFY_VERTICAL_PADDING_DP.dp
+private fun RowDensity.verticalPadding(): Dp = when (this) {
+    RowDensity.Compact -> COMPACT_VERTICAL_PADDING_DP.dp
+    RowDensity.Comfy -> COMFY_VERTICAL_PADDING_DP.dp
 }
 
 @Composable
@@ -101,7 +101,7 @@ fun EndpointsWidget(
         state = state,
         selectedKey = selectedKey,
         onFilterUpdate = viewModel::onFilterChanged,
-        onDensityChanged = viewModel::onDensityChanged,
+        onRowDensityChanged = viewModel::onRowDensityChanged,
         onEndpointClicked = { key ->
             selectedKey = key
             onEndpointClicked(key)
@@ -121,20 +121,20 @@ private fun EndpointsList(
     selectedKey: Key?,
     onEndpointClicked: (Key) -> Unit,
     onFilterUpdate: (String) -> Unit,
-    onDensityChanged: (Density) -> Unit,
+    onRowDensityChanged: (RowDensity) -> Unit,
 ) = Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
     FilterTextField(value = state.filter, onFilterUpdate = onFilterUpdate)
     EndpointsHeader(
         displayedCount = state.endpoints.size,
         totalCount = state.allEndpoints.size,
-        selectedDensity = state.density,
-        onDensityChanged = onDensityChanged,
+        selectedRowDensity = state.rowDensity,
+        onRowDensityChanged = onRowDensityChanged,
     )
     HorizontalDivider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f))
     state.endpoints.forEach { endpoint ->
         EndpointRow(
             endpoint = endpoint,
-            density = state.density,
+            rowDensity = state.rowDensity,
             isSelected = endpoint.key == selectedKey,
             onEndpointClicked = onEndpointClicked,
         )
@@ -145,8 +145,8 @@ private fun EndpointsList(
 private fun EndpointsHeader(
     displayedCount: Int,
     totalCount: Int,
-    selectedDensity: Density,
-    onDensityChanged: (Density) -> Unit,
+    selectedRowDensity: RowDensity,
+    onRowDensityChanged: (RowDensity) -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -161,11 +161,11 @@ private fun EndpointsHeader(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-            listOf(Density.Compact, Density.Comfy).forEach { density ->
-                DensityButton(
+            listOf(RowDensity.Compact, RowDensity.Comfy).forEach { density ->
+                RowDensityButton(
                     label = density.name.lowercase(),
-                    isSelected = selectedDensity == density,
-                    onClick = { onDensityChanged(density) },
+                    isSelected = selectedRowDensity == density,
+                    onClick = { onRowDensityChanged(density) },
                 )
             }
         }
@@ -173,7 +173,7 @@ private fun EndpointsHeader(
 }
 
 @Composable
-private fun DensityButton(
+private fun RowDensityButton(
     label: String,
     isSelected: Boolean,
     onClick: () -> Unit
@@ -196,7 +196,7 @@ private fun DensityButton(
 @Composable
 private fun EndpointRow(
     endpoint: EndpointsViewModel.State.EndpointConfig,
-    density: Density,
+    rowDensity: RowDensity,
     isSelected: Boolean,
     onEndpointClicked: (Key) -> Unit,
     strings: Strings = LocalStrings.current,
@@ -232,15 +232,15 @@ private fun EndpointRow(
             .padding(
                 start = CONTENT_START_PADDING_DP.dp,
                 end = 12.dp,
-                top = density.verticalPadding(),
-                bottom = density.verticalPadding(),
+                top = rowDensity.verticalPadding(),
+                bottom = rowDensity.verticalPadding(),
             ),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Column(modifier = Modifier.weight(1f)) {
             EndpointRowMainContent(endpoint = endpoint)
-            if (density != Density.Compact) {
+            if (rowDensity != RowDensity.Compact) {
                 Spacer(Modifier.height(4.dp))
                 EndpointRowChips(endpoint = endpoint)
             }
@@ -307,7 +307,7 @@ private fun EndpointsWidgetContent(
     state: EndpointsViewModel.State,
     selectedKey: Key?,
     onFilterUpdate: (String) -> Unit,
-    onDensityChanged: (Density) -> Unit,
+    onRowDensityChanged: (RowDensity) -> Unit,
     onEndpointClicked: (Key) -> Unit,
     onGlobalControlsClicked: () -> Unit,
     strings: Strings = LocalStrings.current
@@ -335,7 +335,7 @@ private fun EndpointsWidgetContent(
                         selectedKey = selectedKey,
                         onEndpointClicked = onEndpointClicked,
                         onFilterUpdate = onFilterUpdate,
-                        onDensityChanged = onDensityChanged,
+                        onRowDensityChanged = onRowDensityChanged,
                     )
                     FloatingActionButton(
                         modifier = Modifier
@@ -440,10 +440,10 @@ private fun EndpointsWidgetPreview() = PreviewSurface(darkTheme = true) {
                 ),
             ),
             filter = "",
-            density = Density.Comfy,
+            rowDensity = RowDensity.Comfy,
         ),
         onFilterUpdate = {},
-        onDensityChanged = {},
+        onRowDensityChanged = {},
         onEndpointClicked = {},
         onGlobalControlsClicked = {}
     )

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsViewModel.kt
@@ -46,7 +46,8 @@ internal class GlobalControlsViewModel(
                         key = it.key,
                         name = it.name,
                         fail = it.shouldFail == true,
-                        overriddenProperties = it.getOverriddenProperties()
+                        overriddenProperties = it.getOverriddenProperties(),
+                        delayMs = it.delayMs,
                     )
                 }
                 State.Idle(

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsViewModelTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsViewModelTests.kt
@@ -56,7 +56,8 @@ class GlobalControlsViewModelTests : CoroutineTest() {
                 EndpointProperties.Body.takeIf { _ -> config.defaultBody != null || config.appliedPresetOverride?.response?.body != null },
                 EndpointProperties.Status.takeIf { _ -> config.defaultStatus != null || config.appliedPresetOverride?.response?.statusCode != null },
                 EndpointProperties.Headers.takeIf { _ -> config.defaultHeaders != null || config.appliedPresetOverride?.response?.headers != null }
-            )
+            ),
+            delayMs = config.delayMs,
         )
     }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/endpoints/details/EndpointsViewModelTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/widgets/endpoints/details/EndpointsViewModelTests.kt
@@ -21,6 +21,8 @@ import kotlin.test.assertEquals
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.yield
 
+private const val DUMMY_DELAY_MS = 10
+
 @Suppress("TOO_LONG_FUNCTION")
 class EndpointsViewModelTests : CoroutineTest() {
     private val defaultEndpointList = State.EndpointsList(
@@ -29,22 +31,25 @@ class EndpointsViewModelTests : CoroutineTest() {
                 key = EndpointConfiguration.Key("Key1"),
                 name = "Name1",
                 fail = false,
-                overriddenProperties = emptyList()
+                overriddenProperties = emptyList(),
+                delayMs = null,
             ),
             State.EndpointConfig(
                 key = EndpointConfiguration.Key("Key2"),
                 name = "Name2",
                 fail = true,
-                overriddenProperties = emptyList()
+                overriddenProperties = emptyList(),
+                delayMs = null,
             ),
             State.EndpointConfig(
                 key = EndpointConfiguration.Key("Key3"),
                 name = "Name3",
                 fail = true,
-                overriddenProperties = listOf(EndpointProperties.Delay)
-            )
+                overriddenProperties = listOf(EndpointProperties.Delay),
+                delayMs = DUMMY_DELAY_MS,
+            ),
         ),
-        filter = ""
+        filter = "",
     )
 
     @RelaxedMockK
@@ -72,7 +77,7 @@ class EndpointsViewModelTests : CoroutineTest() {
                         SerializableEndpointConfig.allNulls("Key2", "Name2", 1)
                             .copy(shouldFail = true),
                         SerializableEndpointConfig.allNulls("Key3", "Name3", 1)
-                            .copy(shouldFail = true, delayMs = 10),
+                            .copy(shouldFail = true, delayMs = DUMMY_DELAY_MS),
                     )
                 )
             )
@@ -99,7 +104,7 @@ class EndpointsViewModelTests : CoroutineTest() {
                     SerializableEndpointConfig.allNulls("Key2", "Name2", 1)
                         .copy(shouldFail = true),
                     SerializableEndpointConfig.allNulls("Key3", "Name3", 1)
-                        .copy(shouldFail = true, delayMs = 10),
+                        .copy(shouldFail = true, delayMs = DUMMY_DELAY_MS),
                 )
             )
         )


### PR DESCRIPTION
**Endpoints List UI**

- Rebuilt EndpointRow layout — name + chips in a weighted Column, with delay text, FORCED chip, and chevron all sitting in the outer Row at CenterVertically, eliminating the previous misalignment
- Left accent border now follows a strict priority: fail → error, non-delay overrides → teal, delay-only → amber, none → transparent
- Comfy density chip layout now uses FlowRow to prevent chips overflowing into trailing content on narrow rows
- Divider color corrected to onSurface.copy(alpha = 0.12f) throughout the list