### PR TITLE
Feature/UI overall refinements deviders

### DIFF
--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/Dividers.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/Dividers.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.apadmi.mockzilla.desktop.ui.utils.horizontalResizeCursor
 import com.apadmi.mockzilla.desktop.ui.utils.verticalResizeCursor
@@ -19,11 +19,12 @@ internal fun HorizontalDraggableDivider(
     onDrag: (Float) -> Unit,
     onDragStopped: () -> Unit,
 ) {
+    val dividerColor = MaterialTheme.colorScheme.outlineVariant
     Box(
         modifier = Modifier
-            .background(color = Color.Black)
+            .background(color = dividerColor)
             .fillMaxHeight()
-            .width(3.dp)
+            .width(1.dp)
             .horizontalResizeCursor()
             .draggable(
                 state = rememberDraggableState { dragAmount ->
@@ -41,11 +42,12 @@ internal fun VerticalDraggableDivider(
     onDragStarted: () -> Unit = {},
     onDragStopped: () -> Unit,
 ) {
+    val dividerColor = MaterialTheme.colorScheme.outlineVariant
     Box(
         modifier = Modifier
-            .background(color = Color.Black)
+            .background(color = dividerColor)
             .fillMaxWidth()
-            .height(3.dp)
+            .height(1.dp)
             .verticalResizeCursor()
             .draggable(
                 state = rememberDraggableState { dragAmount ->

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/Dividers.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/Dividers.kt
@@ -19,7 +19,7 @@ internal fun HorizontalDraggableDivider(
     onDrag: (Float) -> Unit,
     onDragStopped: () -> Unit,
 ) {
-    val dividerColor = MaterialTheme.colorScheme.outlineVariant
+    val dividerColor = MaterialTheme.colorScheme.outline
     Box(
         modifier = Modifier
             .background(color = dividerColor)
@@ -42,7 +42,7 @@ internal fun VerticalDraggableDivider(
     onDragStarted: () -> Unit = {},
     onDragStopped: () -> Unit,
 ) {
-    val dividerColor = MaterialTheme.colorScheme.outlineVariant
+    val dividerColor = MaterialTheme.colorScheme.outline
     Box(
         modifier = Modifier
             .background(color = dividerColor)

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
@@ -22,6 +22,7 @@ import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTab
 import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTabList
 
 private const val LEFT_PANEL_MIN_WIDTH_DP = 280
+private const val RIGHT_PANEL_MIN_WIDTH_DP = 720
 
 /**
  * @property title
@@ -60,8 +61,8 @@ fun WidgetScaffold(
     // with the cursor at all times.
     var leftPanelWidth by remember { mutableStateOf(LEFT_PANEL_MIN_WIDTH_DP.dp) }
     var leftPanelSettledWidth by remember { mutableStateOf(LEFT_PANEL_MIN_WIDTH_DP.dp) }
-    var rightPanelWidth by remember { mutableStateOf(280.dp) }
-    var rightPanelSettledWidth by remember { mutableStateOf(280.dp) }
+    var rightPanelWidth by remember { mutableStateOf(RIGHT_PANEL_MIN_WIDTH_DP.dp) }
+    var rightPanelSettledWidth by remember { mutableStateOf(RIGHT_PANEL_MIN_WIDTH_DP.dp) }
 
     // Both of the horizontal panels must collectively not be so large that the center panel
     // runs out of space. We can enforce this by hoisting the width of each panel and preventing
@@ -69,7 +70,10 @@ fun WidgetScaffold(
     val centerMinWidth = 300.dp
     val leftPanelWidthRestriction = { width: Dp ->
         if (totalWidth > 0.dp) {
-            val remaining = totalWidth - centerMinWidth - max(rightPanelSettledWidth, 0.dp)
+            val remaining = max(
+                LEFT_PANEL_MIN_WIDTH_DP.dp,
+                totalWidth - centerMinWidth - max(rightPanelSettledWidth, RIGHT_PANEL_MIN_WIDTH_DP.dp)
+            )
             min(max(LEFT_PANEL_MIN_WIDTH_DP.dp, width), remaining)
         } else {
             max(LEFT_PANEL_MIN_WIDTH_DP.dp, width)
@@ -77,10 +81,13 @@ fun WidgetScaffold(
     }
     val rightPanelWidthRestriction = { width: Dp ->
         if (totalWidth > 0.dp) {
-            val remaining = totalWidth - centerMinWidth - max(leftPanelSettledWidth, 0.dp)
-            min(max(0.dp, width), remaining)
+            val remaining = max(
+                RIGHT_PANEL_MIN_WIDTH_DP.dp,
+                totalWidth - centerMinWidth - max(leftPanelSettledWidth, LEFT_PANEL_MIN_WIDTH_DP.dp)
+            )
+            min(max(RIGHT_PANEL_MIN_WIDTH_DP.dp, width), remaining)
         } else {
-            max(0.dp, width)
+            max(RIGHT_PANEL_MIN_WIDTH_DP.dp, width)
         }
     }
     Box(

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.unit.min
 import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTab
 import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTabList
 
+private const val LEFT_PANEL_MIN_WIDTH_DP = 280
+
 /**
  * @property title
  * @property ui
@@ -56,8 +58,8 @@ fun WidgetScaffold(
     // width/height below zero (when the user drags into the tab areas) but visually display the
     // restricted width/height that can't drop below 0. This ensures the dragged divider stays
     // with the cursor at all times.
-    var leftPanelWidth by remember { mutableStateOf(230.dp) }
-    var leftPanelSettledWidth by remember { mutableStateOf(230.dp) }
+    var leftPanelWidth by remember { mutableStateOf(LEFT_PANEL_MIN_WIDTH_DP.dp) }
+    var leftPanelSettledWidth by remember { mutableStateOf(LEFT_PANEL_MIN_WIDTH_DP.dp) }
     var rightPanelWidth by remember { mutableStateOf(280.dp) }
     var rightPanelSettledWidth by remember { mutableStateOf(280.dp) }
 
@@ -68,9 +70,9 @@ fun WidgetScaffold(
     val leftPanelWidthRestriction = { width: Dp ->
         if (totalWidth > 0.dp) {
             val remaining = totalWidth - centerMinWidth - max(rightPanelSettledWidth, 0.dp)
-            min(max(0.dp, width), remaining)
+            min(max(LEFT_PANEL_MIN_WIDTH_DP.dp, width), remaining)
         } else {
-            max(0.dp, width)
+            max(LEFT_PANEL_MIN_WIDTH_DP.dp, width)
         }
     }
     val rightPanelWidthRestriction = { width: Dp ->

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
@@ -21,8 +21,8 @@ import androidx.compose.ui.unit.min
 import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTab
 import com.apadmi.mockzilla.ui.ui.common.scaffold.VerticalTabList
 
-private const val LEFT_PANEL_MIN_WIDTH_DP = 280
-private const val RIGHT_PANEL_MIN_WIDTH_DP = 720
+private const val leftPanelMinWidthDp = 280
+private const val rightPanelMinWidthDp = 720
 
 /**
  * @property title
@@ -59,10 +59,10 @@ fun WidgetScaffold(
     // width/height below zero (when the user drags into the tab areas) but visually display the
     // restricted width/height that can't drop below 0. This ensures the dragged divider stays
     // with the cursor at all times.
-    var leftPanelWidth by remember { mutableStateOf(LEFT_PANEL_MIN_WIDTH_DP.dp) }
-    var leftPanelSettledWidth by remember { mutableStateOf(LEFT_PANEL_MIN_WIDTH_DP.dp) }
-    var rightPanelWidth by remember { mutableStateOf(RIGHT_PANEL_MIN_WIDTH_DP.dp) }
-    var rightPanelSettledWidth by remember { mutableStateOf(RIGHT_PANEL_MIN_WIDTH_DP.dp) }
+    var leftPanelWidth by remember { mutableStateOf(leftPanelMinWidthDp.dp) }
+    var leftPanelSettledWidth by remember { mutableStateOf(leftPanelMinWidthDp.dp) }
+    var rightPanelWidth by remember { mutableStateOf(rightPanelMinWidthDp.dp) }
+    var rightPanelSettledWidth by remember { mutableStateOf(rightPanelMinWidthDp.dp) }
 
     // Both of the horizontal panels must collectively not be so large that the center panel
     // runs out of space. We can enforce this by hoisting the width of each panel and preventing
@@ -71,23 +71,23 @@ fun WidgetScaffold(
     val leftPanelWidthRestriction = { width: Dp ->
         if (totalWidth > 0.dp) {
             val remaining = max(
-                LEFT_PANEL_MIN_WIDTH_DP.dp,
-                totalWidth - centerMinWidth - max(rightPanelSettledWidth, RIGHT_PANEL_MIN_WIDTH_DP.dp)
+                leftPanelMinWidthDp.dp,
+                totalWidth - centerMinWidth - max(rightPanelSettledWidth, rightPanelMinWidthDp.dp)
             )
-            min(max(LEFT_PANEL_MIN_WIDTH_DP.dp, width), remaining)
+            min(max(leftPanelMinWidthDp.dp, width), remaining)
         } else {
-            max(LEFT_PANEL_MIN_WIDTH_DP.dp, width)
+            max(leftPanelMinWidthDp.dp, width)
         }
     }
     val rightPanelWidthRestriction = { width: Dp ->
         if (totalWidth > 0.dp) {
             val remaining = max(
-                RIGHT_PANEL_MIN_WIDTH_DP.dp,
-                totalWidth - centerMinWidth - max(leftPanelSettledWidth, LEFT_PANEL_MIN_WIDTH_DP.dp)
+                rightPanelMinWidthDp.dp,
+                totalWidth - centerMinWidth - max(leftPanelSettledWidth, leftPanelMinWidthDp.dp)
             )
-            min(max(RIGHT_PANEL_MIN_WIDTH_DP.dp, width), remaining)
+            min(max(rightPanelMinWidthDp.dp, width), remaining)
         } else {
-            max(RIGHT_PANEL_MIN_WIDTH_DP.dp, width)
+            max(rightPanelMinWidthDp.dp, width)
         }
     }
     Box(

--- a/mockzilla-management-ui/mockzilla-desktop/src/desktopMain/kotlin/Main.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/desktopMain/kotlin/Main.kt
@@ -11,7 +11,7 @@ import com.apadmi.mockzilla.desktop.utils.rememberAppIcon
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
 
-private const val minWindowSizeDp = 300
+private const val minWindowSizeDp = 1300
 
 fun main() = application {
     val state = rememberWindowState(

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
@@ -77,7 +77,8 @@ val EnStrings = Strings(
             ios = "iOS",
             jvm = "JVM",
             js = "Web - JS",
-            deviceSection = "Device"
+            deviceSection = "Device",
+            error = "Failed to load device info",
         ),
         logs = Strings.Widgets.Logs(
             title = "Logs",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
@@ -170,6 +170,7 @@ data class Strings(
             val jvm: String,
             val js: String,
             val deviceSection: String,
+            val error: String,
         )
 
         /**

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -312,7 +311,7 @@ private fun EndpointsWidgetContent(
     onGlobalControlsClicked: () -> Unit,
     strings: Strings = LocalStrings.current
 ) {
-    val horizontalScrollState = rememberScrollState()
+    val scrollState = rememberScrollState()
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
@@ -321,8 +320,7 @@ private fun EndpointsWidgetContent(
         val contentWidth = maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp)
         Box(
             modifier = Modifier
-                .fillMaxHeight()
-                .horizontalScroll(horizontalScrollState)
+                .horizontalScroll(scrollState)
                 .width(contentWidth)
                 .padding(horizontal = 12.dp, vertical = 15.dp)
                 .navigationBarsPadding()

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/endpoints/EndpointsWidget.kt
@@ -64,7 +64,7 @@ import com.apadmi.mockzilla.ui.ui.common.theme.warning
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
-private const val MIN_CONTENT_WIDTH_DP = 300
+private const val minContentWidthDp = 300
 private const val HOVER_ALPHA = 0.08f
 private const val UNSELECTED_BORDER_ALPHA = 0.2f
 private const val LEFT_BORDER_WIDTH_DP = 3
@@ -317,7 +317,7 @@ private fun EndpointsWidgetContent(
             .fillMaxSize()
             .background(color = MaterialTheme.colorScheme.background)
     ) {
-        val contentWidth = maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp)
+        val contentWidth = maxOf(maxWidth, minContentWidthDp.dp)
         Box(
             modifier = Modifier
                 .horizontalScroll(scrollState)
@@ -325,32 +325,32 @@ private fun EndpointsWidgetContent(
                 .padding(horizontal = 12.dp, vertical = 15.dp)
                 .navigationBarsPadding()
         ) {
-            when (state) {
-                EndpointsViewModel.State.Loading -> CircularProgressIndicator()
-                is EndpointsViewModel.State.EndpointsList -> {
-                    EndpointsList(
-                        state = state,
-                        selectedKey = selectedKey,
-                        onEndpointClicked = onEndpointClicked,
-                        onFilterUpdate = onFilterUpdate,
-                        onRowDensityChanged = onRowDensityChanged,
+        when (state) {
+            EndpointsViewModel.State.Loading -> CircularProgressIndicator()
+            is EndpointsViewModel.State.EndpointsList -> {
+                EndpointsList(
+                    state = state,
+                    selectedKey = selectedKey,
+                    onEndpointClicked = onEndpointClicked,
+                    onFilterUpdate = onFilterUpdate,
+                    onRowDensityChanged = onRowDensityChanged,
+                )
+                FloatingActionButton(
+                    modifier = Modifier
+                        .padding(end = 8.dp)
+                        .align(Alignment.BottomEnd)
+                        .zIndex(1f),
+                    onClick = onGlobalControlsClicked,
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    contentColor = MaterialTheme.colorScheme.onPrimary
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Settings,
+                        contentDescription = strings.widgets.globalControls.title
                     )
-                    FloatingActionButton(
-                        modifier = Modifier
-                            .padding(end = 8.dp)
-                            .align(Alignment.BottomEnd)
-                            .zIndex(1f),
-                        onClick = onGlobalControlsClicked,
-                        containerColor = MaterialTheme.colorScheme.primary,
-                        contentColor = MaterialTheme.colorScheme.onPrimary
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.Settings,
-                            contentDescription = strings.widgets.globalControls.title
-                        )
-                    }
                 }
             }
+        }
         }
     }
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/metadata/MetaDataWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/metadata/MetaDataWidget.kt
@@ -4,8 +4,10 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +15,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.CircularProgressIndicator
@@ -46,6 +50,8 @@ import org.koin.core.parameter.parametersOf
 
 import kotlin.String
 
+private const val MIN_CONTENT_WIDTH_DP = 280
+
 private fun RunTarget.label(strings: Strings) = when (this) {
     RunTarget.AndroidDevice,
     RunTarget.AndroidEmulator -> strings.widgets.metaData.android
@@ -71,14 +77,20 @@ fun MetaDataWidgetContent(
     state: MetaDataWidgetViewModel.State,
     device: Device? = null,
     strings: Strings = LocalStrings.current
-) = Box(
-    Modifier.fillMaxWidth(),
-    contentAlignment = Alignment.Center
 ) {
-    when (state) {
-        is MetaDataWidgetViewModel.State.DisplayMetaData -> MetaDataListView(state, device, strings)
-        MetaDataWidgetViewModel.State.Error -> Text("Error")
-        MetaDataWidgetViewModel.State.Loading -> CircularProgressIndicator()
+    val scrollState = rememberScrollState()
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val contentWidth = maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp)
+        Box(
+            modifier = Modifier.horizontalScroll(scrollState).width(contentWidth),
+            contentAlignment = Alignment.Center
+        ) {
+            when (state) {
+                is MetaDataWidgetViewModel.State.DisplayMetaData -> MetaDataListView(state, device, strings)
+                MetaDataWidgetViewModel.State.Error -> Text("Error")
+                MetaDataWidgetViewModel.State.Loading -> CircularProgressIndicator()
+            }
+        }
     }
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/metadata/MetaDataWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/metadata/MetaDataWidget.kt
@@ -87,7 +87,7 @@ fun MetaDataWidgetContent(
         ) {
             when (state) {
                 is MetaDataWidgetViewModel.State.DisplayMetaData -> MetaDataListView(state, device, strings)
-                MetaDataWidgetViewModel.State.Error -> Text("Error")
+                MetaDataWidgetViewModel.State.Error -> Text(strings.widgets.metaData.error)
                 MetaDataWidgetViewModel.State.Loading -> CircularProgressIndicator()
             }
         }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/metadata/MetaDataWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/metadata/MetaDataWidget.kt
@@ -4,10 +4,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -16,7 +14,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material3.CircularProgressIndicator
@@ -50,8 +47,6 @@ import org.koin.core.parameter.parametersOf
 
 import kotlin.String
 
-private const val MIN_CONTENT_WIDTH_DP = 280
-
 private fun RunTarget.label(strings: Strings) = when (this) {
     RunTarget.AndroidDevice,
     RunTarget.AndroidEmulator -> strings.widgets.metaData.android
@@ -78,18 +73,14 @@ fun MetaDataWidgetContent(
     device: Device? = null,
     strings: Strings = LocalStrings.current
 ) {
-    val scrollState = rememberScrollState()
-    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-        val contentWidth = maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp)
-        Box(
-            modifier = Modifier.horizontalScroll(scrollState).width(contentWidth),
-            contentAlignment = Alignment.Center
-        ) {
-            when (state) {
-                is MetaDataWidgetViewModel.State.DisplayMetaData -> MetaDataListView(state, device, strings)
-                MetaDataWidgetViewModel.State.Error -> Text(strings.widgets.metaData.error)
-                MetaDataWidgetViewModel.State.Loading -> CircularProgressIndicator()
-            }
+    Box(
+        modifier = Modifier.fillMaxWidth(),
+        contentAlignment = Alignment.Center
+    ) {
+        when (state) {
+            is MetaDataWidgetViewModel.State.DisplayMetaData -> MetaDataListView(state, device, strings)
+            MetaDataWidgetViewModel.State.Error -> Text(strings.widgets.metaData.error)
+            MetaDataWidgetViewModel.State.Loading -> CircularProgressIndicator()
         }
     }
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/misccontrols/MiscControlsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/misccontrols/MiscControlsWidget.kt
@@ -2,9 +2,7 @@ package com.apadmi.mockzilla.ui.ui.common.widgets.misccontrols
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -53,8 +50,6 @@ import com.apadmi.mockzilla.ui.ui.common.theme.ScaleFactor
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
-private const val MIN_CONTENT_WIDTH_DP = 280
-
 private data object PresentationModeScaleFactor {
     const val MIN = 0.8F
     const val MAX = 1.4F
@@ -88,11 +83,12 @@ fun MiscControlsWidgetContent(
     onClearAllOverrides: () -> Unit,
     strings: Strings = LocalStrings.current
 ) {
-    val scrollState = rememberScrollState()
-    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-        val contentWidth = maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp)
-        Column(modifier = Modifier.horizontalScroll(scrollState).width(contentWidth).padding(horizontal = 16.dp, vertical = 8.dp)) {
-    SectionHeader(title = strings.widgets.miscControls.actionsSection)
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        SectionHeader(title = strings.widgets.miscControls.actionsSection)
 
     Spacer(modifier = Modifier.height(4.dp))
 
@@ -143,7 +139,6 @@ fun MiscControlsWidgetContent(
             PresentationModeScaleFactor.scaleFactor = scaleFactor
         },
     )
-        }
     }
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/misccontrols/MiscControlsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/misccontrols/MiscControlsWidget.kt
@@ -2,7 +2,9 @@ package com.apadmi.mockzilla.ui.ui.common.widgets.misccontrols
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -50,6 +53,8 @@ import com.apadmi.mockzilla.ui.ui.common.theme.ScaleFactor
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.core.parameter.parametersOf
 
+private const val MIN_CONTENT_WIDTH_DP = 280
+
 private data object PresentationModeScaleFactor {
     const val MIN = 0.8F
     const val MAX = 1.4F
@@ -82,7 +87,11 @@ fun MiscControlsWidgetContent(
     onRefreshAll: () -> Unit,
     onClearAllOverrides: () -> Unit,
     strings: Strings = LocalStrings.current
-) = Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+) {
+    val scrollState = rememberScrollState()
+    BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+        val contentWidth = maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp)
+        Column(modifier = Modifier.horizontalScroll(scrollState).width(contentWidth).padding(horizontal = 16.dp, vertical = 8.dp)) {
     SectionHeader(title = strings.widgets.miscControls.actionsSection)
 
     Spacer(modifier = Modifier.height(4.dp))
@@ -134,6 +143,8 @@ fun MiscControlsWidgetContent(
             PresentationModeScaleFactor.scaleFactor = scaleFactor
         },
     )
+        }
+    }
 }
 
 @Preview


### PR DESCRIPTION
**
_Panel width enforcement (WidgetScaffold, Main.kt)_
**

- Added LEFT_PANEL_MIN_WIDTH_DP = 280 and RIGHT_PANEL_MIN_WIDTH_DP = 720 constants
- Left divider can no longer be dragged so far right that it squeezes the editor/log panel below 720dp
- Restriction lambdas now clamp remaining space to a positive floor — previously, on small window sizes the remaining calculation went negative, collapsing the left panel entirely and hiding the MetaDataWidget with no way to recover
- Raised minimum OS window size from 300dp → 1300dp to match combined panel minimums (280 + 300 + 720)
- Horizontal scroll with minimum width (MetaDataWidget, MiscControlsWidget, EndpointsWidget)

- Wrapped content in BoxWithConstraints + horizontalScroll + width(maxOf(maxWidth, MIN_CONTENT_WIDTH_DP.dp))
- Content holds its layout at minimum width and scrolls horizontally when the window is resized from corners, instead of crushing text vertically
- Endpoint list selection & hover (EndpointsWidget)

- Clicked row retains its highlight background after click (previously cleared on mouse-move)
- Selected row shows a teal left accent bar
- Hover highlight works correctly in dark mode before click
- Divider styling (Dividers.kt)
- Changed from hardcoded Color.Black at 3dp to MaterialTheme.colorScheme.outlineVariant at 1dp
- Divider now adapts to light and dark mode correctly

**Testing**
- Resize window from corners — widgets scroll horizontally, no text wrapping vertically
- Drag left divider to the right — stops before squeezing editor panel below 720dp
- Drag left divider to the left — stops at 280dp, MetaDataWidget never disappears
- Endpoint list — click a row, move mouse away, highlight persists
- Light and dark mode — divider line and hover states render correctly in both