### PR TITLE
Feature/tabs styling behaviour animation

### DIFF
--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
@@ -2,16 +2,23 @@
 
 package com.apadmi.mockzilla.desktop.ui.scaffold
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandHorizontally
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkHorizontally
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
@@ -273,34 +280,39 @@ private fun RightPanel(
     }
 
     Row(modifier = Modifier.fillMaxHeight()) {
-        if (selectedWidgets.isNotEmpty()) {
-            HorizontalDraggableDivider(
-                onDrag = { offset ->
-                    with(density) {
-                        onWidthChange(width - offset.toDp())
-                    }
-                },
-                onDragStopped = onDragStopped,
-            )
-        }
-
-        Surface(
-            modifier = Modifier
-                .verticalScroll(rememberScrollState())
-                .fillMaxHeight()
-                .width(if (selectedWidgets.isEmpty()) {
-                    0.dp
-                } else {
-                    settledWidth
-                })
+        AnimatedVisibility(
+            visible = selectedWidgets.isNotEmpty(),
+            enter = expandHorizontally(
+                expandFrom = Alignment.End,
+                animationSpec = tween(durationMillis = 160),
+            ) + fadeIn(animationSpec = tween(durationMillis = 120)),
+            exit = shrinkHorizontally(
+                shrinkTowards = Alignment.End,
+                animationSpec = tween(durationMillis = 130),
+            ) + fadeOut(animationSpec = tween(durationMillis = 100)),
         ) {
-            if (selectedWidgets.isNotEmpty()) {
-                Column {
-                    selectedWidgets.sorted().forEachIndexed { index, widget ->
-                        if (index != 0) {
-                            HorizontalDivider(Modifier.padding(vertical = 8.dp))
+            Row {
+                HorizontalDraggableDivider(
+                    onDrag = { offset ->
+                        with(density) {
+                            onWidthChange(width - offset.toDp())
                         }
-                        content.getOrNull(widget)?.ui?.invoke()
+                    },
+                    onDragStopped = onDragStopped,
+                )
+                Surface(
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .fillMaxHeight()
+                        .width(settledWidth)
+                ) {
+                    Column {
+                        selectedWidgets.sorted().forEachIndexed { index, widget ->
+                            if (index != 0) {
+                                HorizontalDivider(Modifier.padding(vertical = 8.dp))
+                            }
+                            content.getOrNull(widget)?.ui?.invoke()
+                        }
                     }
                 }
             }

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/scaffold/WidgetScaffold.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -306,6 +307,7 @@ private fun RightPanel(
         }
 
         val tabWidgets = content.filter { it.title != null }
+        VerticalDivider(color = MaterialTheme.colorScheme.outline)
         VerticalTabList(
             tabs = tabWidgets.map { widget -> VerticalTab(title = widget.title) },
             clockwise = true,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/scaffold/Tabs.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/scaffold/Tabs.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/scaffold/Tabs.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/scaffold/Tabs.kt
@@ -151,9 +151,9 @@ private fun TabItem(
     val colorScheme = MaterialTheme.colorScheme
     Box(
         modifier = modifier
-            .background(if (selected) colorScheme.surface else Color.Transparent)
+            .background(Color.Transparent)
             .selectable(selected = selected, onClick = onSelect)
-            .heightIn(min = 44.dp),
+            .heightIn(min = 30.dp),
         contentAlignment = Alignment.Center,
     ) {
         if (selected) {
@@ -173,8 +173,7 @@ private fun TabItem(
         }
         Row(
             modifier = Modifier
-                .minimumInteractiveComponentSize()
-                .padding(horizontal = 16.dp, vertical = 10.dp),
+                .padding(horizontal = 10.dp, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             leadingContent?.invoke()


### PR DESCRIPTION
Summary

> Restyled the vertical tab strip to match the design: strip background uses surfaceContainerLow (dark) / surfaceContainer (light), selected tab shows a teal accent bar along the bottom edge via drawBehind, and selected/unselected text uses primary / onSurfaceVariant respectively
> Added outline-coloured edge line to the tab strip via drawBehind (left edge for clockwise, right edge for counter-clockwise)
> Added a VerticalDivider (outline colour) between the content panel and the right-side tab strip in RightPanel
> Animated the right panel open/close using AnimatedVisibility with expandHorizontally / shrinkHorizontally — same duration spec as MonitorLogsWidget (enter 160 ms + fade 120 ms, exit 130 ms + fade 100 ms) so the panel smoothly slides in from the right when a tab is selected and collapses back when deselected