### PR TITLE
feat: support management UI through browserstack

### DIFF
--- a/build-logic/src/main/kotlin/com/apadmi/mockzilla/MobileUiConfig.kt
+++ b/build-logic/src/main/kotlin/com/apadmi/mockzilla/MobileUiConfig.kt
@@ -3,7 +3,7 @@ package com.apadmi.mockzilla
 import org.gradle.api.Project
 
 object MobileUiConfig {
-    const val coreVersionForManagementUi = "3.0.0-alpha2"
+    const val coreVersionForManagementUi = "to be updated during release"
 }
 
 fun Project.isMobileUiDeployBuild() = properties["is_building_for_deployment"].toString().toBoolean()

--- a/docs/docs/browser_stack.md
+++ b/docs/docs/browser_stack.md
@@ -12,7 +12,6 @@ Browserstack seems to proxy local traffic by default. In your client app you'll 
 ```kotlin
 OkHttpClient.Builder()
     .proxy(Proxy.NO_PROXY)
-    .protocols(listOf(Protocol.HTTP_1_1)).build()
 ```
 
 ### Ktor Example:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ buildKonfig = "0.20.0" # https://github.com/yshrsmz/BuildKonfig
 dokka = "2.2.0" # https://github.com/Kotlin/dokka
 
 # Localization
-lyricist = "1.8.0" # https://github.com/adrielcafe/lyricist
+lyricist = "1.7.0" # https://github.com/adrielcafe/lyricist
 
 # Networking
 ktor = "3.4.3" # https://github.com/ktorio/ktor
@@ -93,6 +93,7 @@ semver = { module = "io.github.z4kn4fein:semver", version.ref = "semver" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-js = { module = "io.ktor:ktor-client-js", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/di/utils/KoinHandler.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/di/utils/KoinHandler.kt
@@ -8,6 +8,7 @@ import com.apadmi.mockzilla.ui.engine.device.ActiveDeviceMonitor
 import com.apadmi.mockzilla.ui.engine.device.ActiveDeviceSelector
 import com.apadmi.mockzilla.ui.engine.events.EventBus
 import com.apadmi.mockzilla.ui.engine.events.EventBusImpl
+import com.apadmi.mockzilla.ui.utils.Platform
 
 import org.koin.core.module.Module
 import org.koin.dsl.binds
@@ -22,15 +23,21 @@ object MockzillaUiKoinContext {
 
     @OptIn(DelicateCoroutinesApi::class)
     private val koinApp = koinApplication {
+        val mockzillaManagement = MockzillaManagement.constructInstance(config = MockzillaManagement.Config(
+            // Bypasses proxy when running on mobile devices since the server is on device
+            // going via a proxy can redirect calls to the proxy machine instead of the local device
+            // (Notably this is needed for Mockzilla to run on Browserstack)
+            disableProxy = Platform.current != Platform.Desktop
+        ))
         modules(
             viewModelModule(),
             useCaseModule(),
             module {
-                single { MockzillaManagement.instance.metaDataService }
-                single { MockzillaManagement.instance.logsService }
-                single { MockzillaManagement.instance.endpointsService }
-                single { MockzillaManagement.instance.updateService }
-                single { MockzillaManagement.instance.cacheClearingService }
+                single { mockzillaManagement.metaDataService }
+                single { mockzillaManagement.logsService }
+                single { mockzillaManagement.endpointsService }
+                single { mockzillaManagement.updateService }
+                single { mockzillaManagement.cacheClearingService }
                 single<EventBus> { EventBusImpl(GlobalScope) }
                 single { ActiveDeviceManagerImpl(get(), GlobalScope) } binds arrayOf(
                     ActiveDeviceMonitor::class,

--- a/mockzilla-management/build.gradle.kts
+++ b/mockzilla-management/build.gradle.kts
@@ -84,6 +84,12 @@ kotlin {
             /* Logging */
             implementation(libs.kermit)
         }
+        jvmMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
+        }
+        iosMain.dependencies {
+            implementation(libs.ktor.client.darwin)
+        }
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)

--- a/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/MockzillaManagement.kt
+++ b/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/MockzillaManagement.kt
@@ -72,6 +72,12 @@ interface MockzillaManagement {
         ): Result<MonitorLogsResponse>
     }
 
+    /**
+     * @property disableProxy
+     */
+    data class Config(
+        val disableProxy: Boolean = false
+    )
     private data class Instance(
         override val underlyingRepository: MockzillaManagementRepository,
         override val updateService: UpdateService,
@@ -82,9 +88,12 @@ interface MockzillaManagement {
     ) : MockzillaManagement
 
     companion object {
-        val instance: MockzillaManagement by lazy {
-            val repo = MockzillaManagementRepositoryImpl.create()
-            Instance(repo, UpdateServiceImpl(repo), repo, repo, repo, repo)
+        @Deprecated("This property is deprecated")
+        val instance: MockzillaManagement by lazy { constructInstance() }
+
+        fun constructInstance(config: Config = Config()): MockzillaManagement {
+            val repo = MockzillaManagementRepositoryImpl.create(config)
+            return Instance(repo, UpdateServiceImpl(repo), repo, repo, repo, repo)
         }
     }
 }

--- a/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/MockzillaManagementRepositoryImpl.kt
+++ b/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/MockzillaManagementRepositoryImpl.kt
@@ -136,10 +136,13 @@ MockzillaManagement.CacheClearingService {
     }
 
     companion object {
-        internal fun create(logger: KtorLogger) = MockzillaManagementRepositoryImpl(
-            KtorRequestRunner(KtorClientProvider.createKtorClient(logger = logger))
+        internal fun create(config: MockzillaManagement.Config, logger: KtorLogger) = MockzillaManagementRepositoryImpl(
+            KtorRequestRunner(KtorClientProvider.createKtorClient(
+                disableProxy = config.disableProxy,
+                logger = logger
+            ))
         )
 
-        fun create() = create(KtorLogger.SIMPLE)
+        fun create(config: MockzillaManagement.Config) = create(config, KtorLogger.SIMPLE)
     }
 }

--- a/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.kt
+++ b/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.kt
@@ -3,7 +3,6 @@ package com.apadmi.mockzilla.management.internal.ktor
 import com.apadmi.mockzilla.lib.internal.utils.JsonProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
-import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -15,13 +14,14 @@ import io.ktor.serialization.kotlinx.json.json
 internal object CustomHeaders {
     const val HideFromLogs = "hide-from-logs"
 }
+
 internal object KtorClientProvider {
-    fun createKtorClient(engine: HttpClientEngine? = null, logger: Logger = Logger.SIMPLE) =
-        engine?.let {
-            HttpClient(engine) {
-                httpClientConfig(logger)
-            }
-        } ?: HttpClient { httpClientConfig(logger) }
+    fun createKtorClient(
+        disableProxy: Boolean,
+        logger: Logger = Logger.SIMPLE
+    ) = createPlatformKtorClient(disableProxy) {
+        httpClientConfig(logger)
+    }
 
     private fun HttpClientConfig<*>.httpClientConfig(logger: Logger) {
         install(ContentNegotiation) {
@@ -39,3 +39,8 @@ internal object KtorClientProvider {
         install(Resources)
     }
 }
+
+internal expect fun createPlatformKtorClient(
+    disableProxy: Boolean,
+    configure: HttpClientConfig<*>.() -> Unit
+): HttpClient

--- a/mockzilla-management/src/commonTest/kotlin/com/apadmi/mockzilla/management/internal/service/UpdateServiceIntegrationTests.kt
+++ b/mockzilla-management/src/commonTest/kotlin/com/apadmi/mockzilla/management/internal/service/UpdateServiceIntegrationTests.kt
@@ -7,6 +7,7 @@ import com.apadmi.mockzilla.lib.models.EndpointConfiguration
 import com.apadmi.mockzilla.lib.models.MockzillaConfig
 import com.apadmi.mockzilla.lib.models.PartialMockzillaHttpResponse
 import com.apadmi.mockzilla.management.MockzillaConnectionConfig
+import com.apadmi.mockzilla.management.MockzillaManagement
 import com.apadmi.mockzilla.management.internal.MockzillaManagementRepositoryImpl
 import com.apadmi.mockzilla.testutils.runIntegrationTest
 import io.ktor.client.plugins.logging.Logger
@@ -20,7 +21,7 @@ class UpdateServiceIntegrationTests {
 
     private suspend fun getEndpointConfig(
         connection: MockzillaConnectionConfig
-    ) = MockzillaManagementRepositoryImpl.create(Logger.SIMPLE)
+    ) = MockzillaManagementRepositoryImpl.create(MockzillaManagement.Config(), Logger.SIMPLE)
         .fetchAllEndpointConfigs(connection)
         .getOrThrow()
         .first { it.key == dummyConfig.key }

--- a/mockzilla-management/src/commonTest/kotlin/com/apadmi/mockzilla/testutils/IntegrationTestRunner.kt
+++ b/mockzilla-management/src/commonTest/kotlin/com/apadmi/mockzilla/testutils/IntegrationTestRunner.kt
@@ -5,6 +5,7 @@ import com.apadmi.mockzilla.lib.models.MockzillaConfig
 import com.apadmi.mockzilla.lib.models.MockzillaRuntimeParams
 import com.apadmi.mockzilla.lib.stopMockzilla
 import com.apadmi.mockzilla.management.MockzillaConnectionConfig
+import com.apadmi.mockzilla.management.MockzillaManagement.*
 import com.apadmi.mockzilla.management.internal.MockzillaManagementRepository
 import com.apadmi.mockzilla.management.internal.MockzillaManagementRepositoryImpl
 import io.ktor.client.plugins.logging.Logger
@@ -35,7 +36,10 @@ internal fun <Sut> runIntegrationTest(
     testBlock: TestBlock<Sut>
 ) = runTest {
     /* Setup */
-    val repo = MockzillaManagementRepositoryImpl.create(logger = Logger.SIMPLE)
+    val repo = MockzillaManagementRepositoryImpl.create(
+        config = Config(),
+        logger = Logger.SIMPLE
+    )
     val runtimeParams = startTestingMockzilla(appName, appVersion, config)
 
     /* Run Test */

--- a/mockzilla-management/src/iosMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.ios.kt
+++ b/mockzilla-management/src/iosMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.ios.kt
@@ -1,0 +1,18 @@
+package com.apadmi.mockzilla.management.internal.ktor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+
+internal actual fun createPlatformKtorClient(
+    disableProxy: Boolean,
+    configure: io.ktor.client.HttpClientConfig<*>.() -> Unit
+) = HttpClient(Darwin) {
+    engine {
+        if (disableProxy) {
+            configureSession {
+                // Empty dictionary means no proxy
+                connectionProxyDictionary = emptyMap<Any?, Any?>()
+            }
+        }
+    }
+}

--- a/mockzilla-management/src/iosMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.ios.kt
+++ b/mockzilla-management/src/iosMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.ios.kt
@@ -15,4 +15,6 @@ internal actual fun createPlatformKtorClient(
             }
         }
     }
+
+    configure()
 }

--- a/mockzilla-management/src/jsMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.jsMain.kt
+++ b/mockzilla-management/src/jsMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.jsMain.kt
@@ -1,0 +1,11 @@
+package com.apadmi.mockzilla.management.internal.ktor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+
+internal actual fun createPlatformKtorClient(
+    disableProxy: Boolean,
+    configure: HttpClientConfig<*>.() -> Unit
+) = HttpClient {
+    configure()
+}

--- a/mockzilla-management/src/jvmMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.jvm.kt
+++ b/mockzilla-management/src/jvmMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.jvm.kt
@@ -1,0 +1,24 @@
+package com.apadmi.mockzilla.management.internal.ktor
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.okhttp.OkHttp
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import java.net.Proxy
+
+internal actual fun createPlatformKtorClient(
+    disableProxy: Boolean,
+    configure: HttpClientConfig<*>.() -> Unit
+) = HttpClient(OkHttp) {
+    engine {
+        if (disableProxy) {
+            preconfigured = OkHttpClient.Builder()
+                .proxy(Proxy.NO_PROXY)
+                .protocols(listOf(Protocol.HTTP_1_1))
+                .build()
+        }
+    }
+
+    configure()
+}

--- a/mockzilla-management/src/jvmMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.jvm.kt
+++ b/mockzilla-management/src/jvmMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorClientProvider.jvm.kt
@@ -4,7 +4,6 @@ import io.ktor.client.HttpClient
 import io.ktor.client.HttpClientConfig
 import io.ktor.client.engine.okhttp.OkHttp
 import okhttp3.OkHttpClient
-import okhttp3.Protocol
 import java.net.Proxy
 
 internal actual fun createPlatformKtorClient(
@@ -15,7 +14,6 @@ internal actual fun createPlatformKtorClient(
         if (disableProxy) {
             preconfigured = OkHttpClient.Builder()
                 .proxy(Proxy.NO_PROXY)
-                .protocols(listOf(Protocol.HTTP_1_1))
                 .build()
         }
     }


### PR DESCRIPTION
Browserstack's proxy messes up the embedded UI so this change bypasses all proxies when management UI is running on device.

This doesn't force anyone running the management package on mobile to skip proxy, only through our UI.

Also lyricist bump was causing a runtime crash so this has been reverted