### PR TITLE
feature/monior-logs-logs-detail-state-management 

### DIFF
--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/DesktopAppRoot.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/DesktopAppRoot.kt
@@ -165,7 +165,9 @@ fun DesktopApp(
                     state = state,
                     onViewDetail = {
                         logDetail = it
-                        onSelected(logDetailsWidgetId)
+                        if (!openWidgets.contains(logDetailsWidgetId)) {
+                            onSelected(logDetailsWidgetId)
+                        }
                     },
                     strings = strings,
                 ).forEach { widget -> widget.ui() }


### PR DESCRIPTION
Implemented the same fix for the Monitor Logs widget to ensure the log details panel remains open when interacting with log entries, updating the panel state appropriately instead of unexpectedly closing it.