### PR TITLE
Feature/UI minor refinements editor section

### DIFF
--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/PresetCard.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/PresetCard.kt
@@ -13,10 +13,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -64,6 +67,7 @@ import com.apadmi.mockzilla.ui.ui.common.assets.EditUnderscore
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalForceDarkMode
 import com.apadmi.mockzilla.ui.ui.common.theme.StateColors
 import com.apadmi.mockzilla.ui.ui.common.theme.jsonHighlight
+import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
 import com.apadmi.mockzilla.ui.ui.common.theme.success
 import com.apadmi.mockzilla.ui.ui.common.theme.warning
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.details.EndpointDetailsViewModel.State.Endpoint.LayoutMode
@@ -155,12 +159,14 @@ internal fun PresetCard(
     val iconTint = if (isSelected) colorScheme.primary else colorScheme.onSurfaceVariant
     val titleColor = if (isSelected) colorScheme.primary else colorScheme.onSurface
 
+    val hasExpandableContent = !preset.response.body.isNullOrBlank()
     var expanded by rememberSaveable { mutableStateOf(false) }
     val chevronRotation by animateFloatAsState(
         targetValue = if (expanded) 0f else -90f,
         animationSpec = tween(200),
         label = "chevron",
     )
+    val chevronTint = if (hasExpandableContent) iconTint else colorScheme.onSurface.copy(alpha = 0.3f)
 
     Column(
         Modifier.fillMaxWidth()
@@ -179,7 +185,7 @@ internal fun PresetCard(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { expanded = !expanded }
+                .clickable(enabled = hasExpandableContent) { expanded = !expanded }
                 .padding(horizontal = 12.dp, vertical = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -187,7 +193,7 @@ internal fun PresetCard(
                 imageVector = Icons.Default.KeyboardArrowDown,
                 contentDescription = null,
                 modifier = Modifier.size(16.dp).rotate(chevronRotation),
-                tint = iconTint,
+                tint = chevronTint,
             )
             Spacer(Modifier.size(8.dp))
 
@@ -212,31 +218,39 @@ internal fun PresetCard(
 
             when (variant) {
                 PresetCardVariant.Selected -> Row(
+                    modifier = Modifier
+                        .height(IntrinsicSize.Min)
+                        .padding(vertical = 6.dp),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Row(
+                    Box(
                         modifier = Modifier
+                            .fillMaxHeight()
                             .clip(RoundedCornerShape(6.dp))
                             .clickable { onEdit() }
-                            .padding(horizontal = 8.dp, vertical = 4.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
                     ) {
-                        Icon(
-                            imageVector = Icons.EditUnderscore,
-                            contentDescription = null,
-                            modifier = Modifier.size(14.dp),
-                            tint = colorScheme.onSurfaceVariant,
-                        )
-                        Text(
-                            text = strings.editLabel,
-                            style = MaterialTheme.typography.labelMedium,
-                            color = colorScheme.onSurfaceVariant,
+                        Tag(
+                            modifier = Modifier.fillMaxHeight(),
+                            prefix = {
+                                Icon(
+                                    imageVector = Icons.EditUnderscore,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(14.dp),
+                                    tint = colorScheme.onSurface,
+                                )
+                            },
+                            label = strings.editLabel,
+                            textColor = colorScheme.onSurface,
+                            borderColor = colorScheme.outline,
+                            backgroundColor = colorScheme.surfaceContainer,
+                            shape = RoundedCornerShape(6.dp),
+                            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
                         )
                     }
 
                     Tag(
+                        modifier = Modifier.fillMaxHeight(),
                         prefix = {
                             Icon(
                                 modifier = Modifier.size(14.dp),
@@ -271,12 +285,12 @@ internal fun PresetCard(
             }
         }
 
-        if (!isCompact && !preset.description.isNullOrBlank()) {
+        if (expanded && !preset.description.isNullOrBlank()) {
             Text(
-                modifier = Modifier.padding(start = 36.dp, end = 12.dp, bottom = 4.dp),
+                modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 4.dp),
                 text = preset.description ?: "",
                 style = MaterialTheme.typography.bodySmall,
-                color = colorScheme.onSurfaceVariant,
+                color = colorScheme.onSurfaceMuted,
             )
         }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/PresetCard.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/PresetCard.kt
@@ -287,7 +287,7 @@ internal fun PresetCard(
 
         if (expanded && !preset.description.isNullOrBlank()) {
             Text(
-                modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 4.dp, bottom = 4.dp),
+                modifier = Modifier.padding(start = 12.dp, end = 12.dp, top = 4.dp),
                 text = preset.description ?: "",
                 style = MaterialTheme.typography.bodySmall,
                 color = colorScheme.onSurfaceMuted,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/components/PresetsContainer.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/components/PresetsContainer.kt
@@ -210,7 +210,9 @@ private fun PopulatedPresets(
         }
 
         presets.visiblePresets.forEachIndexed { index, preset ->
-            if (index > 0) {
+            if (index == 0) {
+                Spacer(Modifier.height(4.dp))
+            } else {
                 Spacer(Modifier.height(4.dp))
                 HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.5f))
                 Spacer(Modifier.height(4.dp))
@@ -226,6 +228,9 @@ private fun PopulatedPresets(
                 onEdit = onEditPreset,
                 layoutMode = layoutMode
             )
+            if (index == presets.visiblePresets.lastIndex) {
+                Spacer(Modifier.height(4.dp))
+            }
         }
     }
 }

--- a/samples/demo-android/src/main/java/com/apadmi/mockzilla/demo/engine/mock/MockServer.kt
+++ b/samples/demo-android/src/main/java/com/apadmi/mockzilla/demo/engine/mock/MockServer.kt
@@ -18,6 +18,7 @@ private val getMyPig = EndpointConfiguration
     .configureDashboardOverrides {
         addPreset(
             name = "George",
+            description = "A pig called George",
             response = MockzillaHttpResponse(
                 body = Json.encodeToString(
                     AnimalDto(
@@ -33,11 +34,13 @@ private val getMyPig = EndpointConfiguration
 
         addPreset(
             name = "Pig Failure",
+            description = "Simulates a 404 Not Found error from the pig endpoint",
             response = MockzillaHttpResponse(statusCode = HttpStatusCode.NotFound)
         )
 
         addPreset(
             name = "Pig Malformed Response",
+            description = "Simulates a malformed, unparseable response from the pig endpoint",
             response = MockzillaHttpResponse(body = "Pig Malformed Response")
         )
     }
@@ -62,7 +65,8 @@ private val getMySheep = EndpointConfiguration
     .setPatternMatcher { uri.endsWith("sheep") }
     .configureDashboardOverrides {
         addPreset(
-            name = "",
+            name = "Dolly",
+            description = "The world's first cloned mammal, a Finn-Dorset sheep born in 1996",
             response = MockzillaHttpResponse(
                 body = Json.encodeToString(
                     AnimalDto(
@@ -78,11 +82,13 @@ private val getMySheep = EndpointConfiguration
 
         addPreset(
             name = "Sheep Failure",
+            description = "Simulates a 400 Bad Request error from the sheep endpoint",
             response = MockzillaHttpResponse(statusCode = HttpStatusCode.BadRequest)
         )
 
         addPreset(
             name = "Sheep Malformed Response",
+            description = "Simulates a malformed, unparseable response from the sheep endpoint",
             response = MockzillaHttpResponse(body = "Sheep Malformed Response")
         )
     }
@@ -108,6 +114,7 @@ private val getMyCow = EndpointConfiguration
     .configureDashboardOverrides {
         addPreset(
             name = "Angry Bessie",
+            description = "A famously long-lived Irish cow who held two Guinness World Records",
             response = MockzillaHttpResponse(
                 body = Json.encodeToString(
                     AnimalDto(
@@ -123,11 +130,13 @@ private val getMyCow = EndpointConfiguration
 
         addPreset(
             name = "Cow Failure",
+            description = "Simulates a 404 Not Found error from the cow endpoint",
             response = MockzillaHttpResponse(statusCode = HttpStatusCode.NotFound)
         )
 
         addPreset(
             name = "Cow Malformed Response",
+            description = "Simulates a malformed, unparseable response from the cow endpoint",
             response = MockzillaHttpResponse(body = "Cow Malformed Response")
         )
     }


### PR DESCRIPTION
1. On presets that have nothing to expand can we disable the chevron?
2. when expanded preset descriptions should be visible (the sample app doesn't have any you'd need to add one)
.configureDashboardOverrides {
    addPreset(
        name = "George",
        description = "A pig called George", <---- this line
3. Padding around the preset rows
4. Edit button style