### PR TITLE
fix: improve window closing times

### DIFF
--- a/mockzilla-management-ui/mockzilla-desktop/src/androidMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.android.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/androidMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.android.kt
@@ -8,5 +8,5 @@ actual class ZeroConfSdkWrapper actual constructor(serviceType: String, scope: C
         Logger.i { "Skipping ZeroConf setup: Not available on Android target" }
     }
 
-    actual fun stop() = Unit
+    actual suspend fun stop() = Unit
 }

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.kt
@@ -36,5 +36,5 @@ data class DeviceDiscoveryEvent(
 
 expect class ZeroConfSdkWrapper(serviceType: String, scope: CoroutineScope) {
     fun setListener(listener: suspend (DeviceDiscoveryEvent) -> Unit)
-    fun stop()
+    suspend fun stop()
 }

--- a/mockzilla-management-ui/mockzilla-desktop/src/desktopMain/kotlin/Main.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/desktopMain/kotlin/Main.kt
@@ -1,6 +1,7 @@
 @file:Suppress("PACKAGE_NAME_MISSING")
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,8 +29,17 @@ import co.touchlab.kermit.Logger
 import org.jetbrains.skiko.OS
 import org.jetbrains.skiko.hostOs
 
+import java.awt.Desktop
 import java.awt.Dimension
 import java.awt.GraphicsEnvironment
+
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.time.withTimeout
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 
 private const val minWindowSizeDp = 400
 
@@ -90,17 +100,40 @@ fun main() = application {
     Logger.setLogWriters(logWriters = listOf(DesktopLogWriter()))
     startDesktopMockzillaKoin()
 
+    var isWindowVisible by remember { mutableStateOf(true) }
+
+    // Handle Cmd+Q
+    LaunchedEffect(Unit) {
+        if (hostOs == OS.MacOS) {
+            Desktop.getDesktop().setQuitHandler { _, response ->
+                performGracefulShutdown({ isWindowVisible = false }, response::performQuit)
+            }
+        }
+    }
+
     Window(
         title = "Mockzilla",
         resizable = true,
         state = state,
         icon = rememberAppIcon(),
+        visible = isWindowVisible,
         onCloseRequest = {
-            MockzillaUiKoinContext.koin.get<ZeroConfSdkWrapper>().stop()
-            exitApplication()
+            performGracefulShutdown({ isWindowVisible = false }, { exitApplication() })
         },
         content = { MockzillaWindowContent(state) }
     )
+}
+
+private fun performGracefulShutdown(onHidden: () -> Unit, onDone: () -> Unit) {
+    onHidden()
+    CoroutineScope(Dispatchers.IO).launch {
+        // Usually only takes ~2 seconds but just ensuring Mockzilla doesn't become un-quittable
+        // if `stop` somehow gets stuck
+        withTimeout(30.seconds) {
+            MockzillaUiKoinContext.koin.get<ZeroConfSdkWrapper>().stop()
+        }
+        withContext(Dispatchers.Main) { onDone() }
+    }
 }
 
 @Composable

--- a/mockzilla-management-ui/mockzilla-desktop/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.desktop.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/desktopMain/kotlin/com/apadmi/mockzilla/desktop/engine/connection/ZeroConfSdkWrapper.desktop.kt
@@ -16,6 +16,8 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -23,6 +25,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.yield
 
 private const val tag = "ZeroConfSdkWrapper"
 private const val bufferCapacity = 16
@@ -52,11 +55,17 @@ actual class ZeroConfSdkWrapper actual constructor(
         }
     }
 
-    actual fun stop() {
+    actual suspend fun stop() {
         pollingJob?.cancel()
         pollingJob = null
-        jmDnsInstances.values.forEach { runCatching { it.close() } }
+        val closingJobs = jmDnsInstances.values.map {
+            scope.async {
+                runCatching { it.close() }
+                yield()
+            }
+        }
         jmDnsInstances.clear()
+        closingJobs.awaitAll()
     }
 
     private fun syncInterfaces() {


### PR DESCRIPTION
There isn't an obvious way of clearing up the JMDNS instances faster so instead we close the window and only quit the underlying application a few seconds later once the cleanup is complete.

Also parallelises the actual shutdown of the jmnds instances to further speed things up