### PR TITLE
refactor: Reduce duplication in text field state for CreateEditPreset…

### DIFF
--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/EditorTextField.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/EditorTextField.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.input.OutputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
 import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Error
 import androidx.compose.material3.Icon
@@ -37,7 +36,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -68,9 +66,6 @@ import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
 import com.apadmi.mockzilla.ui.ui.common.utils.formatting.BodyVisualTransformation
 
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
-
 private const val editorDefaultHeightDp = 200
 private const val textMeasureCacheSize = 64
 
@@ -80,8 +75,7 @@ internal enum class EditorMode {
 
 @Composable
 internal fun EditorTextField(
-    body: String,
-    onBodyChange: (String) -> Unit,
+    textFieldState: TextFieldState,
     mode: EditorMode,
     isExpanded: Boolean,
     modifier: Modifier = Modifier,
@@ -89,7 +83,6 @@ internal fun EditorTextField(
     parseError: String? = null,
     additionalOutputTransformation: OutputTransformation? = null,
     currentMatch: IntRange? = null,
-    textFieldState: TextFieldState = rememberTextFieldState(body),
 ) {
     val strings = LocalStrings.current.components.editor
     val colorScheme = MaterialTheme.colorScheme
@@ -98,24 +91,7 @@ internal fun EditorTextField(
 
     var fieldHeight by remember { mutableStateOf(editorDefaultHeightDp.dp) }
     var lineCount by remember { mutableStateOf(1) }
-    val isLargeFile = BodyVisualTransformation.isBodyTooLarge(body)
-    val textFieldState = rememberTextFieldState(body)
-
-    LaunchedEffect(body) {
-        if (textFieldState.text.toString() != body) {
-            textFieldState.edit {
-                replace(0, length, body)
-                selection = TextRange(length)
-            }
-        }
-    }
-
-    LaunchedEffect(textFieldState) {
-        snapshotFlow { textFieldState.text.toString() }
-            .drop(1)
-            .distinctUntilChanged()
-            .collect { onBodyChange(it) }
-    }
+    val isLargeFile = BodyVisualTransformation.isBodyTooLarge(textFieldState.text.toString())
 
     val textStyle = MaterialTheme.typography.bodyMedium.copy(
         color = colorScheme.onSurface,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/FindableEditorTextField.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/FindableEditorTextField.kt
@@ -19,7 +19,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.DoneAll
@@ -64,19 +64,17 @@ import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 @Composable
 internal fun FindableEditorTextField(
-    body: String,
-    onBodyChange: (String) -> Unit,
+    textFieldState: TextFieldState,
     mode: EditorMode,
     isExpanded: Boolean,
     modifier: Modifier = Modifier,
     placeholder: String,
     parseError: String? = null,
 ) {
-    val textFieldState = rememberTextFieldState(body)
     var state by remember { mutableStateOf(FindReplaceState()) }
 
-    LaunchedEffect(body, state.searchTerm) {
-        val newMatches = findMatches(body, state.searchTerm)
+    LaunchedEffect(textFieldState.text, state.searchTerm) {
+        val newMatches = findMatches(textFieldState.text.toString(), state.searchTerm)
         state = state.copy(
             matches = newMatches,
             currentMatchIndex = state.currentMatchIndex.coerceIn(
@@ -155,8 +153,7 @@ internal fun FindableEditorTextField(
         }
     ) {
         EditorTextField(
-            body = body,
-            onBodyChange = onBodyChange,
+            textFieldState = textFieldState,
             mode = mode,
             isExpanded = isExpanded,
             modifier = Modifier.fillMaxWidth(),
@@ -164,7 +161,6 @@ internal fun FindableEditorTextField(
             parseError = parseError,
             additionalOutputTransformation = highlightTransformation,
             currentMatch = if (state.isPanelOpen) state.matches.getOrNull(state.currentMatchIndex) else null,
-            textFieldState = textFieldState,
         )
 
         AnimatedVisibility(
@@ -182,15 +178,20 @@ internal fun FindableEditorTextField(
                 onReplace = {
                     if (state.matches.isNotEmpty()) {
                         val match = state.matches[state.currentMatchIndex]
-                        val newBody = body.substring(0, match.first) +
+                        val oldBody = textFieldState.text
+                        val newBody = oldBody.substring(0, match.first) +
                                 state.replaceTerm +
-                                body.substring(match.last + 1)
-                        onBodyChange(newBody)
+                                oldBody.substring(match.last + 1)
+                        textFieldState.edit { replace(0, length, newBody) }
                     }
                 },
                 onReplaceAll = {
                     if (state.searchTerm.isNotEmpty()) {
-                        onBodyChange(body.replace(state.searchTerm, state.replaceTerm, ignoreCase = true))
+                        val oldBody = textFieldState.text.toString()
+                        val newBody = oldBody.replace(
+                            state.searchTerm, state.replaceTerm, ignoreCase = true
+                        )
+                        textFieldState.edit { replace(0, length, newBody) }
                     }
                 },
             )

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -54,6 +56,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -96,6 +99,9 @@ import com.apadmi.mockzilla.ui.utils.minimumTouchTarget
 
 import io.ktor.http.HttpStatusCode
 import org.koin.core.parameter.parametersOf
+
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 
 @Composable
 private fun ColumnScope.HeadersSection(
@@ -479,11 +485,17 @@ private fun BodySection(
 ) {
     // Local state drives the text field to avoid cursor-jump glitches from the VM round-trip.
     // Syncs from VM only when syncToken changes (server reload or format applied).
-    var localBody by remember { mutableStateOf(state.body ?: "") }
-    LaunchedEffect(state.syncToken) { localBody = state.body ?: "" }
+    val localBody = rememberTextFieldState(state.body ?: "")
+    LaunchedEffect(state.syncToken) { localBody.setTextAndPlaceCursorAtEnd(state.body ?: "") }
+    LaunchedEffect(localBody) {
+        snapshotFlow { localBody.text }
+            .drop(1)
+            .distinctUntilChanged()
+            .collect { onNewResponseBody(it.toString()) }
+    }
 
     val isJsonError = state.responseType == State.Editing.ResponseType.Json &&
-            localBody.isNotEmpty() && state.bodyParseError != null
+            localBody.text.isNotEmpty() && state.bodyParseError != null
     val isFormattable = state.responseType == State.Editing.ResponseType.Json
 
     Row(
@@ -501,14 +513,14 @@ private fun BodySection(
 
         if (isJsonError) {
             Text(
-                text = strings.responseCharacters(localBody.length),
+                text = strings.responseCharacters(localBody.text.length),
                 style = MaterialTheme.typography.labelSmall.copy(fontFamily = LocalMonoFontFamily.current),
                 color = MaterialTheme.colorScheme.error,
                 modifier = Modifier.weight(1f)
             )
         } else {
             Text(
-                text = strings.responseCharacters(localBody.length),
+                text = strings.responseCharacters(localBody.text.length),
                 style = MaterialTheme.typography.labelSmall.copy(fontFamily = LocalMonoFontFamily.current),
                 color = MaterialTheme.colorScheme.onSurfaceFaint,
                 modifier = Modifier.weight(1f)
@@ -538,11 +550,7 @@ private fun BodySection(
     }
 
     FindableEditorTextField(
-        body = localBody,
-        onBodyChange = {
-            localBody = it
-            onNewResponseBody(it)
-        },
+        textFieldState = localBody,
         mode = when (state.responseType) {
             State.Editing.ResponseType.Json -> EditorMode.Json
             State.Editing.ResponseType.Html -> EditorMode.Html


### PR DESCRIPTION
Now uses a single TextFieldState syncronised with the view model instead of synchronising a String state with the view model then synchronising that with a TextFieldState further down the UI tree, the latter synchronisation of which could have caused unwanted selection state reset issues. Due to odd behaviour in Compose, selection state is still lost on focusing anything else on the UI, so the UI behaviour remains unchanged and selection state is still lost on find+replace or switching body type.

This resolves https://github.com/Apadmi-Engineering/Mockzilla/issues/679