### PR TITLE
feat: improve llm consumption of mockzilla docs

### DIFF
--- a/docs/docs/additional_config.md
+++ b/docs/docs/additional_config.md
@@ -1,3 +1,6 @@
+---
+description: Configure logging verbosity and Release Mode (rate limiting, token auth, and localhost-only access) for sharing mock builds with non-developers.
+---
 
 # Additional Configuration
 

--- a/docs/docs/browser_stack.md
+++ b/docs/docs/browser_stack.md
@@ -1,3 +1,7 @@
+---
+description: Run Mockzilla on BrowserStack devices - iOS works out of the box; Android requires bypassing BrowserStack's local-traffic proxy in your HTTP client.
+---
+
 # BrowserStack
 
 ## iOS

--- a/docs/docs/desktop/overview.md
+++ b/docs/docs/desktop/overview.md
@@ -92,7 +92,7 @@ Each entry shows the request URL, status code, and response time - colour-coded 
 Alongside the device/app info panel you'll find a few utility controls:
 
 - **Refresh all** - re-fetches the latest state from the connected device.
-- **Clear overrides** - resets all changes back to the configuration defined in code. (Same as "Reset all" in Global Controls).
+- **Clear overrides** - same as "Reset all" in Global Controls.
 - **Presentation mode** - scales the entire UI, handy when demoing on a projector or a shared screen.
 - **Dark mode** - forces dark theme regardless of your OS setting.
 

--- a/docs/docs/endpoints.md
+++ b/docs/docs/endpoints.md
@@ -15,7 +15,7 @@ description: Learn how to configure Mockzilla endpoints - define custom handlers
                 headers = mapOf("test-header" to "test-value"),
                 body = "{}"
             )
-        })
+        }
         .setPatternMatcher { uri.endsWith("greeting") }
         .build()
     ```
@@ -80,7 +80,7 @@ Example:
         MockzillaHttpResponse(
             body = Json.encodeToString(MyDtoResponseClass("my value"))
         )
-    })
+    }
     ```
 === "Flutter"
     It is recommended to use a JSON serialisation library such as [freezed](https://pub.dev/packages/freezed) or [json_serializable](https://pub.dev/packages/json_serializable) that can generate `toJson()`/`fromJson()` methods for you.
@@ -214,7 +214,7 @@ Mockzilla supports artificially causing network requests to fail.
 **The default is for requests to succeed**.
 
 !!! note
-    Controlling artificial latency/errors in code is time consuming and inflexible. We recommend using the [Mockzilla Desktop](/desktop/overview) app or [Embedded Mobile Ui](/mobile_ui) to do this on the fly.
+    Controlling artificial latency in code is time consuming and inflexible. We recommend using the [Mockzilla Desktop](desktop/overview.md) app or [Embedded Mobile Ui](mobile_ui.md) to do this on the fly.
 
 ## Mock Request Lifecycle
 

--- a/docs/docs/mobile_ui.md
+++ b/docs/docs/mobile_ui.md
@@ -1,3 +1,7 @@
+---
+description: Embed the Mockzilla control UI in your app to override responses and adjust the mock server at runtime - install instructions and launchManagementUi usage per platform.
+---
+
 # Mockzilla Mobile UI (alpha)
 
 !!! warning
@@ -38,7 +42,7 @@ Mockzilla provides an embedded UI for your App to control the server at runtime.
 
 ## Setup
 
-If you've not configured the Mockzilla server yet, then do that first [here](../quick-start/)!
+If you've not configured the Mockzilla server yet, then do that first [here](quick-start.md)!
 
 ### Launch the Embedded UI
 

--- a/docs/docs/overrides/main.html
+++ b/docs/docs/overrides/main.html
@@ -17,7 +17,6 @@
   <meta property="og:title" content="{{ og_title }}">
   <meta property="og:description" content="{{ og_desc }}">
   <meta property="og:url" content="{{ og_url }}">
-  <meta property="og:image" content="{{ og_image }}">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="{{ config.site_name }} — {{ config.site_description }}">
@@ -25,7 +24,6 @@
   {# Twitter card tags need no account; they only control how a shared link renders on X. #}
   <meta name="twitter:title" content="{{ og_title }}">
   <meta name="twitter:description" content="{{ og_desc }}">
-  <meta name="twitter:image" content="{{ og_image }}">
 
   <link rel="icon" type="image/svg+xml" href="{{ 'img/icon.svg' | url }}">
   <meta name="theme-color" content="#141414">

--- a/docs/docs/overrides/main.html
+++ b/docs/docs/overrides/main.html
@@ -1,2 +1,33 @@
 {% extends "base.html" %}
 
+{#
+  Inject social-share + discoverability metadata on every content page. Zensical's
+  base.html already emits <title>, description and canonical, but no Open Graph or
+  Twitter card — so links shared in Slack, LinkedIn, Discord, X, iMessage, etc. would
+  otherwise render as bare text with no preview. The homepage does not use this template
+  (it renders from generate-fragment.mjs), so its tags are set there instead.
+#}
+{% block extrahead %}
+  {% if page and page.title %}{% set og_title = page.title | striptags %}{% else %}{% set og_title = config.site_name %}{% endif %}
+  {% if page.meta and page.meta.description %}{% set og_desc = page.meta.description %}{% else %}{% set og_desc = config.site_description %}{% endif %}
+  {% set og_url = page.canonical_url if page.canonical_url else config.site_url %}
+
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ og_title }}">
+  <meta property="og:description" content="{{ og_desc }}">
+  <meta property="og:url" content="{{ og_url }}">
+  <meta property="og:image" content="{{ og_image }}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:image:alt" content="{{ config.site_name }} — {{ config.site_description }}">
+
+  {# Twitter card tags need no account; they only control how a shared link renders on X. #}
+  <meta name="twitter:title" content="{{ og_title }}">
+  <meta name="twitter:description" content="{{ og_desc }}">
+  <meta name="twitter:image" content="{{ og_image }}">
+
+  <link rel="icon" type="image/svg+xml" href="{{ 'img/icon.svg' | url }}">
+  <meta name="theme-color" content="#141414">
+{% endblock %}
+

--- a/docs/docs/presets.md
+++ b/docs/docs/presets.md
@@ -1,7 +1,11 @@
+---
+description: Define presets - canned responses configured in code and applied at runtime from the desktop app or embedded UI - and how partial preset overrides combine with your default handler.
+---
+
 # Presets
 
-Mockzilla responses can be changed and configured at runtime either using our [desktop app](../desktop/overview/) or
-our [embedded UI](../mobile_ui/) that can be included in your app.
+Mockzilla responses can be changed and configured at runtime either using our [desktop app](desktop/overview.md) or
+our [embedded UI](mobile_ui.md) that can be included in your app.
 
 ## What are presets?
 

--- a/docs/docs/quick-start.md
+++ b/docs/docs/quick-start.md
@@ -119,7 +119,7 @@ Mockzilla is entirely driven by a config object which is used to start the serve
         ),
     );
     ```
-See [here](/endpoints/) for more information on configuring your endpoints. (Including compile-time safety!)
+See [here](endpoints.md) for more information on configuring your endpoints. (Including compile-time safety!)
 
 ### (2): Just start the server!
 
@@ -151,7 +151,7 @@ See [here](/endpoints/) for more information on configuring your endpoints. (Inc
         func application(_: UIApplication,
                          didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
         {
-            let config = MockzillaConfig.Builder()...
+            let config = MockzillaConfigBuilder()...
             startMockzilla(config: config)
             
             return true

--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -1,3 +1,7 @@
+---
+description: Try unstable development (snapshot) builds of Mockzilla - Maven snapshot repo for Kotlin, snapshot branches for Swift, and pub.dev pre-releases for Flutter.
+---
+
 # Snapshot builds
 
 !!! warning

--- a/docs/docs/web.md
+++ b/docs/docs/web.md
@@ -24,7 +24,7 @@ calls made by your page. This has a couple of practical implications:
 
 ## Installation
 
-Installation should be through the Kotlin or Flutter mechanisms as described in the [Quick Start](/quick-start) guide.
+Installation should be through the Kotlin or Flutter mechanisms as described in the [Quick Start](quick-start.md) guide.
 
 ## Required: Add the mock service worker script
 

--- a/docs/homepage/generate-fragment.mjs
+++ b/docs/homepage/generate-fragment.mjs
@@ -97,6 +97,11 @@ const fullDocument = `<!DOCTYPE html>
 <meta property="og:title" content="${title}">
 <meta property="og:description" content="${desc}">
 <meta property="og:url" content="${ogUrl}">
+<meta name="twitter:title" content="${title}">
+<meta name="twitter:description" content="${desc}">
+<link rel="icon" type="image/svg+xml" href="/img/icon.svg">
+<link rel="icon" href="/img/favicon.ico">
+<meta name="theme-color" content="#141414">
 <script>${themeInitScript}</script>
 <style>
 ${css}

--- a/docs/main.py
+++ b/docs/main.py
@@ -1,15 +1,66 @@
 import os
 import glob
+import shutil
 from pathlib import Path
 import re
 import platform
 
 download_site_url = "https://install.mockzilla.apadmi.dev"
+site_url = "https://mockzilla.apadmi.dev"
+
+# Consumer-facing docs pages, in reading order. The Contributing pages are
+# intentionally excluded — the llms.txt / llms-full.txt outputs target
+# consumers of the published libraries, not contributors to this repo.
+consumer_pages = [
+    "index.md",
+    "quick-start.md",
+    "endpoints.md",
+    "web.md",
+    "additional_config.md",
+    "browser_stack.md",
+    "snapshots.md",
+    "desktop/overview.md",
+    "mobile_ui.md",
+    "presets.md",
+]
+
+# High-value correctness signals for LLM coding assistants, embedded at the top
+# of both generated files (things an assistant is otherwise prone to get wrong).
+llms_preamble = """\
+Mockzilla is a compile-safe mock HTTP server that runs embedded inside your mobile app during development and testing, letting you mock API responses without a real backend. It targets Android, iOS, Kotlin Multiplatform, Flutter and browser (JS/MSW) apps.
+
+Install coordinates:
+- Kotlin / Android / Kotlin Multiplatform (Maven Central): `com.apadmi:mockzilla` (plus `com.apadmi:mockzilla-common` for the shared models/DSL, and `com.apadmi:mockzilla-mobile-ui` for the embeddable in-app overlay).
+- Flutter (pub.dev): `mockzilla`.
+- Native iOS: `SwiftMockzilla` via Swift Package Manager (`https://github.com/Apadmi-Engineering/SwiftMockzilla.git`) or CocoaPods.
+
+Important notes for code generation:
+- There is NO standalone npm / JavaScript package. Do not use `npm install mockzilla`. Browser support (JS, backed by Mock Service Worker) is only reachable through the Flutter `mockzilla_web` plugin or the Kotlin/JS `com.apadmi:mockzilla` target.
+- Mockzilla is a development and testing tool only. It must never be shipped to production.
+"""
+
+
+def _print_source_file(filename, indent=""):
+    full_path = glob.glob(f'../**/{filename}', recursive=True)[0]
+    return Path(full_path).read_text().replace('\n', '\n' + indent)
+
+
+def _extract_version(build_gradle_path):
+    text = _print_source_file(build_gradle_path)
+    match = re.search(r'version\s*=.*"(.*\..*\..*)"', text)
+    return match.group(1) if match else None
+
+
+def _get_version():
+    return _extract_version("mockzilla/build.gradle.kts")
+
+
+def _get_mobile_ui_version():
+    return _extract_version("mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts")
+
+
 def define_env(env):
   "Hook function"
-
-  def remove_prefix(text, prefix):
-       return text[text.startswith(prefix) and len(prefix):]
 
   @env.macro
   def get_download_site_url():
@@ -17,31 +68,15 @@ def define_env(env):
 
   @env.macro
   def print_source_file(filename, indent = ""):
-      full_path = glob.glob(f'../**/{filename}', recursive=True)[0]
-
-      return Path(full_path).read_text().replace('\n', '\n' + indent)
+      return _print_source_file(filename, indent)
 
   @env.macro
   def get_mobile_ui_version():
-      build_gradle_text = print_source_file("mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts")
-
-      version_pattern = r'version\s*=.*"(.*\..*\..*)"'
-      match = re.search(version_pattern, build_gradle_text)
-      if match:
-          return match.group(1)
-      else:
-          return None
+      return _get_mobile_ui_version()
 
   @env.macro
   def get_version():
-      build_gradle_text = print_source_file("mockzilla/build.gradle.kts")
-
-      version_pattern = r'version\s*=.*"(.*\..*\..*)"'
-      match = re.search(version_pattern, build_gradle_text)
-      if match:
-          return match.group(1)
-      else:
-          return None
+      return _get_version()
 
   @env.macro
   def get_python_version():
@@ -70,3 +105,198 @@ If you are not redirected automatically, follow this <a href='{download_site_url
   # Write the multiline string to the specified file
   with open("docs/download.html", 'w') as file:
       file.write(multiline_string)
+
+
+# Resolvers for the no-argument macros that appear in the consumer pages, used
+# to turn `{{ get_version() }}`-style tokens into real values in llms-full.txt.
+_macro_resolvers = {
+    "get_version()": _get_version,
+    "get_mobile_ui_version()": _get_mobile_ui_version,
+    "get_download_site_url()": lambda: download_site_url,
+}
+
+
+def _resolve_macros(text):
+    def replace(match):
+        resolver = _macro_resolvers.get(match.group(1).strip())
+        return str(resolver()) if resolver else match.group(0)
+    return re.sub(r'\{\{\s*(.*?)\s*\}\}', replace, text)
+
+
+def _parse_frontmatter(block):
+    data = {}
+    for line in block.splitlines():
+        match = re.match(r'\s*([A-Za-z_]+):\s*(.*)', line)
+        if match:
+            data[match.group(1)] = match.group(2).strip()
+    return data
+
+
+def _split_frontmatter(text):
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) == 3:
+            return _parse_frontmatter(parts[1]), parts[2].lstrip("\n")
+    return {}, text
+
+
+def _page_title(frontmatter, body, page):
+    if frontmatter.get("title"):
+        return frontmatter["title"]
+    match = re.search(r'^#\s+(.*)', body, re.MULTILINE)
+    return match.group(1).strip() if match else page[:-len(".md")]
+
+
+def _page_md_url(page):
+    # Clean per-page Markdown lives alongside the HTML, mirroring the source path
+    # (e.g. `desktop/overview.md` -> https://mockzilla.apadmi.dev/desktop/overview.md).
+    return f"{site_url}/{page}"
+
+
+# Link targets allowed to be non-`.md` internal references: images/assets and the
+# Dokka API reference (generated HTML with no Markdown equivalent).
+_allowed_link_suffixes = (".md", ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".mp4")
+
+
+def _iter_link_targets(body):
+    """Yield the URL of every Markdown inline link/image (`[txt](url)` / `![alt](url)`)."""
+    for match in re.finditer(r'\]\(([^)]+)\)', body):
+        # Drop an optional "title" after the URL: [x](url "title").
+        yield match.group(1).split()[0]
+
+
+def _html_doc_link_violations(body):
+    """Return internal links written in HTML form (e.g. `/endpoints/`, `../quick-start/`)
+    instead of the required relative `.md` form.
+
+    These resolve to rendered HTML pages, which breaks the clean-Markdown corpus served
+    to LLM assistants — internal doc links must be relative `.md` links so they work in
+    both the Zensical HTML build and the generated per-page `.md` files."""
+    violations = []
+    for target in _iter_link_targets(body):
+        base = target.split('#', 1)[0]
+        if not base or target.startswith(('http://', 'https://', 'mailto:', '#')):
+            continue
+        if 'dokka' in base or base.endswith(_allowed_link_suffixes):
+            continue
+        violations.append(target)
+    return violations
+
+
+def _write_robots_txt(output_dir):
+    """Write robots.txt pointing crawlers at the sitemap (Zensical emits no robots.txt)."""
+    content = (
+        "User-agent: *\n"
+        "Allow: /\n"
+        "\n"
+        f"Sitemap: {site_url}/sitemap.xml\n"
+    )
+    Path(output_dir, "robots.txt").write_text(content)
+
+
+# Non-page files that sit inside the docs tree get copied verbatim into the build output:
+# `homepage/` (a symlinked Vite build fragment) and `overrides/` (the theme's custom_dir
+# templates, which include a full standalone copy of the homepage). Both are orphaned — not
+# in the nav or sitemap and linked from nowhere
+# Hopefully we can get rid of this after https://github.com/zensical/backlog/issues/65 is finished
+_orphan_output_dirs = ("homepage", "overrides")
+
+
+def _prune_orphan_output(output_dir):
+    for name in _orphan_output_dirs:
+        path = Path(output_dir, name)
+        if path.exists():
+            shutil.rmtree(path)
+
+
+def generate_llms_files(docs_dir="docs", output_dir="site"):
+    """Generate llms.txt and llms-full.txt (https://llmstxt.org) into the built
+    site directory so the Cloudflare Pages deploy serves them at the site root.
+
+    Run after `zensical build`, from the `docs/` directory."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    site_description = ""
+    index_lines = []
+    full_sections = []
+    link_errors = {}
+
+    for page in consumer_pages:
+        frontmatter, body = _split_frontmatter(Path(docs_dir, page).read_text())
+        title = _page_title(frontmatter, body, page)
+        description = frontmatter.get("description", "")
+
+        # The homepage (template: home.html) has an empty Markdown body, so it
+        # yields no useful per-page doc — capture its description for the blockquote
+        # and skip it everywhere else.
+        if page == "index.md":
+            site_description = description
+            continue
+
+        body = _resolve_macros(body).strip()
+        # Ensure each standalone page opens with a title for context when read alone.
+        if not body.startswith("#"):
+            body = f"# {title}\n\n{body}"
+
+        # Guard the convention: internal doc links must be relative .md links.
+        violations = _html_doc_link_violations(body)
+        if violations:
+            link_errors[page] = violations
+
+        # Write the clean per-page Markdown next to the HTML, creating nested dirs
+        # (e.g. site/desktop/) as needed.
+        md_path = Path(output_dir, page)
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text(body)
+
+        url = _page_md_url(page)
+        index_lines.append(
+            f"- [{title}]({url}): {description}" if description else f"- [{title}]({url})"
+        )
+        full_sections.append(f"<!-- Page: {title} — {url} -->\n\n{body}")
+
+    if link_errors:
+        detail = "\n".join(
+            f"  {page}: {', '.join(bad)}" for page, bad in link_errors.items()
+        )
+        raise ValueError(
+            "Internal doc links must be relative .md links, not HTML paths, so they "
+            "resolve in both the HTML site and the generated .md files. Offending "
+            f"links:\n{detail}"
+        )
+
+    llms_txt = "\n".join([
+        "# Mockzilla",
+        "",
+        f"> {site_description}",
+        "",
+        llms_preamble,
+        "## Docs",
+        "",
+        *index_lines,
+        "",
+        "## Optional",
+        "",
+        f"- [API Reference (Kotlin KDoc)]({site_url}/dokka/): Generated Dokka API reference for the Kotlin modules.",
+        "- [GitHub repository](https://github.com/Apadmi-Engineering/Mockzilla): Source, samples and issue tracker.",
+        "",
+    ])
+
+    llms_full = "\n".join([
+        "# Mockzilla — Full Documentation",
+        "",
+        f"> {site_description}",
+        "",
+        llms_preamble,
+        "\n\n---\n\n".join(full_sections),
+        "",
+    ])
+
+    Path(output_dir, "llms.txt").write_text(llms_txt)
+    Path(output_dir, "llms-full.txt").write_text(llms_full)
+
+    # SEO finalisation of the built site: crawler directives + dropping the orphan/duplicate
+    # output the static build leaks. Done here because this is the post-`zensical build` hook
+    # that already owns the `site` output directory (see fastlane/fastfiles/docs.rb).
+    _write_robots_txt(output_dir)
+    _prune_orphan_output(output_dir)

--- a/fastlane/fastfiles/docs.rb
+++ b/fastlane/fastfiles/docs.rb
@@ -20,4 +20,8 @@ lane :generate_docs do
 
     # Build docs
     sh("cd #{lane_context[:repo_root]}/docs; zensical build")
+
+    # Generate llms.txt / llms-full.txt for consumers using LLM coding assistants.
+    # Must run after `zensical build`, which owns the `site` output directory.
+    sh("cd #{lane_context[:repo_root]}/docs; python -c 'import main; main.generate_llms_files()'")
 end


### PR DESCRIPTION
Added llms.txt and llms-full.txt as autogenerated files from existing documentation.

Also produce markdown equivalents for all the main files which are more easily parsed by llms

Harney's agreed to find a couple hours of design time for us to create a little card we can use for link previews too so that should follow