### PR TITLE
Add icon button component

### DIFF
--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/devicetabs/DeviceTabsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/devicetabs/DeviceTabsWidget.kt
@@ -69,7 +69,6 @@ import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceFaint
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
 import com.apadmi.mockzilla.ui.ui.common.theme.success
-import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 import kotlin.Float
 
@@ -364,7 +363,6 @@ private fun DeviceTab(
                 imageVector = Icons.Filled.Close,
                 iconTint = colorScheme.onSurfaceFaint,
                 contentDescription = strings.widgets.deviceTabs.closeButtonDescription,
-                modifier = Modifier.iconButtonSize(),
                 iconSize = 12.dp,
             )
         }

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/devicetabs/DeviceTabsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/devicetabs/DeviceTabsWidget.kt
@@ -29,8 +29,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -66,6 +64,7 @@ import com.apadmi.mockzilla.ui.i18n.Strings
 import com.apadmi.mockzilla.ui.internal.di.utils.getViewModel
 import com.apadmi.mockzilla.ui.ui.common.components.PlatformHorizontalScrollbar
 import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceFaint
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
@@ -206,14 +205,13 @@ internal fun DeviceTabsWidgetContent(
                         )
                     }
                     if (state.devices.isNotEmpty()) {
-                        IconButton(onClick = onAddNewDevice) {
-                            Icon(
-                                modifier = Modifier.size(18.dp),
-                                imageVector = Icons.Filled.Add,
-                                tint = colorScheme.onSurfaceVariant,
-                                contentDescription = strings.widgets.deviceTabs.addDevice,
-                            )
-                        }
+                        CustomIconButton(
+                            onClick = onAddNewDevice,
+                            imageVector = Icons.Filled.Add,
+                            iconTint = colorScheme.onSurfaceVariant,
+                            contentDescription = strings.widgets.deviceTabs.addDevice,
+                            iconSize = 18.dp,
+                        )
                     }
                 }
 
@@ -361,17 +359,14 @@ private fun DeviceTab(
                 )
             }
 
-            IconButton(
+            CustomIconButton(
                 onClick = onClose,
+                imageVector = Icons.Filled.Close,
+                iconTint = colorScheme.onSurfaceFaint,
+                contentDescription = strings.widgets.deviceTabs.closeButtonDescription,
                 modifier = Modifier.iconButtonSize(),
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Close,
-                    contentDescription = strings.widgets.deviceTabs.closeButtonDescription,
-                    tint = colorScheme.onSurfaceFaint,
-                    modifier = Modifier.size(12.dp),
-                )
-            }
+                iconSize = 12.dp,
+            )
         }
     }
 }

--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/licenses/LicensesDialog.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/licenses/LicensesDialog.kt
@@ -18,7 +18,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -38,6 +38,7 @@ import com.apadmi.mockzilla.desktop.engine.licenses.LicenseDisplayModel
 import com.apadmi.mockzilla.desktop.ui.licenses.LicensesViewModel.*
 import com.apadmi.mockzilla.ui.i18n.LocalStrings
 import com.apadmi.mockzilla.ui.internal.di.utils.getViewModel
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
 
@@ -102,13 +103,13 @@ private fun LicensesDialogHeader(onDismiss: () -> Unit) {
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
-        IconButton(onClick = onDismiss) {
-            Icon(
-                imageVector = Icons.Filled.Close,
-                contentDescription = LocalStrings.current.common.closeDescription,
-                modifier = Modifier.size(18.dp),
-            )
-        }
+        CustomIconButton(
+            onClick = onDismiss,
+            imageVector = Icons.Filled.Close,
+            iconTint = LocalContentColor.current,
+            contentDescription = LocalStrings.current.common.closeDescription,
+            iconSize = 18.dp,
+        )
     }
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
@@ -18,7 +18,9 @@ public val EnStrings: Strings = Strings(
         backDescription = "Back",
         debugDescription = "Debug",
         resetDescription = "Reset",
-        deleteDescription = "Delete"
+        deleteDescription = "Delete",
+        globalDescription = "Global Controls",
+        metaDescription = "Meta Data",
     ),
     menu = Strings.Menu(
         openSourceLicenses = "Open source licences",
@@ -294,6 +296,8 @@ public val EnStrings: Strings = Strings(
             responseSectionLabel = "Response",
             bodyLabel = "Body",
             jsonErrorTitle = "Invalid JSON:",
+            collapse = "Collapse",
+            expand = "Expand",
         ),
         openSourceLicenses = Strings.Widgets.OpenSourceLicenses(
             error = "Failed to load licences",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
@@ -84,6 +84,8 @@ public data class Strings(
         val debugDescription: String,
         val resetDescription: String,
         val deleteDescription: String,
+        val globalDescription: String,
+        val metaDescription: String,
     )
     @InternalMockzillaApi
     public data class Widgets(
@@ -369,6 +371,8 @@ public data class Strings(
             val responseSectionLabel: String,
             val bodyLabel: String,
             val jsonErrorTitle: String,
+            val collapse: String,
+            val expand: String,
         )
 
         @InternalMockzillaApi

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/ErrorBanner.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/ErrorBanner.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Circle
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -49,6 +48,7 @@ import com.apadmi.mockzilla.ui.i18n.Strings
 import com.apadmi.mockzilla.ui.ui.common.DeviceRootViewModel.State.*
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonVariant
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomButton
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
 import com.apadmi.mockzilla.ui.ui.common.theme.warning
@@ -176,14 +176,13 @@ public fun ErrorBanner(
                 )
             }
 
-            IconButton(onClick = onDismissError) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.size(12.dp),
-                )
-            }
+            CustomIconButton(
+                onClick = onDismissError,
+                imageVector = Icons.Default.Close,
+                iconTint = MaterialTheme.colorScheme.onSurfaceVariant,
+                contentDescription = LocalStrings.current.common.closeDescription,
+                iconSize = 12.dp,
+            )
         }
 
         AnimatedVisibility(

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
@@ -1,0 +1,75 @@
+package com.apadmi.mockzilla.ui.ui.common.components.buttons
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipAnchorPosition
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
+import com.apadmi.mockzilla.lib.InternalMockzillaApi
+
+@InternalMockzillaApi
+public typealias IconDecorationScope = @Composable (Modifier) -> Unit
+
+@InternalMockzillaApi
+@Composable
+public fun CustomIconButton(
+    onClick: () -> Unit,
+    imageVector: ImageVector,
+    iconTint: Color,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    iconSize: Dp? = null,
+    iconDecoration: @Composable (IconDecorationScope) -> Unit = { content ->
+        content(Modifier)
+    },
+) {
+    ButtonTooltip(
+        label = contentDescription,
+    ) {
+        IconButton(
+            onClick = onClick,
+            modifier = modifier,
+            enabled = enabled,
+        ) {
+            iconDecoration { iconModifier ->
+                Icon(
+                    imageVector = imageVector,
+                    contentDescription = contentDescription,
+                    modifier = iconSize?.let { iconModifier.size(it) } ?: iconModifier,
+                    tint = iconTint,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ButtonTooltip(
+    label: String,
+    content: @Composable () -> Unit,
+) {
+    TooltipBox(
+        positionProvider = TooltipDefaults
+            .rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
+        tooltip = {
+            PlainTooltip {
+                Text(text = label, style = MaterialTheme.typography.labelSmall)
+            }
+        },
+        state = rememberTooltipState(),
+        content = content,
+    )
+}

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
@@ -1,16 +1,8 @@
 package com.apadmi.mockzilla.ui.ui.common.components.buttons
 
 import androidx.compose.foundation.layout.size
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.PlainTooltip
-import androidx.compose.material3.Text
-import androidx.compose.material3.TooltipAnchorPosition
-import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -35,41 +27,18 @@ public fun CustomIconButton(
         content(Modifier)
     },
 ) {
-    ButtonTooltip(
-        label = contentDescription,
+    IconButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
     ) {
-        IconButton(
-            onClick = onClick,
-            modifier = modifier,
-            enabled = enabled,
-        ) {
-            iconDecoration { iconModifier ->
-                Icon(
-                    imageVector = imageVector,
-                    contentDescription = contentDescription,
-                    modifier = iconSize?.let { iconModifier.size(it) } ?: iconModifier,
-                    tint = iconTint,
-                )
-            }
+        iconDecoration { iconModifier ->
+            Icon(
+                imageVector = imageVector,
+                contentDescription = contentDescription,
+                modifier = iconSize?.let { iconModifier.size(it) } ?: iconModifier,
+                tint = iconTint,
+            )
         }
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun ButtonTooltip(
-    label: String,
-    content: @Composable () -> Unit,
-) {
-    TooltipBox(
-        positionProvider = TooltipDefaults
-            .rememberTooltipPositionProvider(TooltipAnchorPosition.Above),
-        tooltip = {
-            PlainTooltip {
-                Text(text = label, style = MaterialTheme.typography.labelSmall)
-            }
-        },
-        state = rememberTooltipState(),
-        content = content,
-    )
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
@@ -1,14 +1,23 @@
 package com.apadmi.mockzilla.ui.ui.common.components.buttons
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.apadmi.mockzilla.lib.InternalMockzillaApi
+import com.apadmi.mockzilla.ui.ui.common.assets.LightningBolt
+import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
 import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 @InternalMockzillaApi
@@ -43,3 +52,30 @@ public fun CustomIconButton(
         }
     }
 }
+
+@Composable
+@Preview
+private fun CustomIconButtonPreview(darkTheme: Boolean = false) = PreviewSurface(darkTheme) {
+    Column(
+        modifier = Modifier.padding(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        CustomIconButton(
+            onClick = {},
+            imageVector = Icons.LightningBolt,
+            iconTint = LocalContentColor.current,
+            contentDescription = "",
+        )
+        CustomIconButton(
+            onClick = {},
+            imageVector = Icons.LightningBolt,
+            iconTint = LocalContentColor.current,
+            contentDescription = "",
+            enabled = false,
+        )
+    }
+}
+
+@Composable
+@Preview
+private fun CustomIconButtonDarkPreview() = CustomIconButtonPreview(darkTheme = true)

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/CustomIconButton.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
 import com.apadmi.mockzilla.lib.InternalMockzillaApi
+import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 @InternalMockzillaApi
 public typealias IconDecorationScope = @Composable (Modifier) -> Unit
@@ -29,7 +30,7 @@ public fun CustomIconButton(
 ) {
     IconButton(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.iconButtonSize(),
         enabled = enabled,
     ) {
         iconDecoration { iconModifier ->

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/DensityButtons.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/DensityButtons.kt
@@ -39,12 +39,14 @@ internal fun RowDensityControls(
     onChanged: (RowDensity) -> Unit = {}
 ) = Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
     listOf(RowDensity.Compact, RowDensity.Comfy).forEach { density ->
-        RowDensityButton(
-            label = density.name.lowercase(),
-            icon = density.icon,
-            isSelected = selected == density,
-            onClick = { onChanged(density) },
-        )
+        ButtonTooltip(label = density.name) {
+            RowDensityButton(
+                label = density.name.lowercase(),
+                icon = density.icon,
+                isSelected = selected == density,
+                onClick = { onChanged(density) },
+            )
+        }
     }
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/DensityButtons.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/buttons/DensityButtons.kt
@@ -39,14 +39,12 @@ internal fun RowDensityControls(
     onChanged: (RowDensity) -> Unit = {}
 ) = Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(4.dp)) {
     listOf(RowDensity.Compact, RowDensity.Comfy).forEach { density ->
-        ButtonTooltip(label = density.name) {
-            RowDensityButton(
-                label = density.name.lowercase(),
-                icon = density.icon,
-                isSelected = selected == density,
-                onClick = { onChanged(density) },
-            )
-        }
+        RowDensityButton(
+            label = density.name.lowercase(),
+            icon = density.icon,
+            isSelected = selected == density,
+            onClick = { onChanged(density) },
+        )
     }
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/FindableEditorTextField.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/FindableEditorTextField.kt
@@ -59,7 +59,6 @@ import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonSize
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonVariant
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomButton
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
-import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 @Composable
 internal fun FindableEditorTextField(
@@ -251,7 +250,6 @@ private fun FindReplaceBar(
                     imageVector = Icons.Default.KeyboardArrowRight,
                     iconTint = colorScheme.onSurfaceVariant,
                     contentDescription = if (state.isReplaceMode) strings.collapseReplaceDescription else strings.expandReplaceDescription,
-                    modifier = Modifier.iconButtonSize(),
                     iconSize = 16.dp,
                     iconDecoration = { content -> content(Modifier.rotate(chevronRotation)) }
                 )
@@ -302,7 +300,6 @@ private fun FindReplaceBar(
                     imageVector = Icons.Default.KeyboardArrowUp,
                     iconTint = colorScheme.onSurfaceVariant,
                     contentDescription = strings.previousMatchDescription,
-                    modifier = Modifier.iconButtonSize(),
                     iconSize = 16.dp,
                 )
                 CustomIconButton(
@@ -311,7 +308,6 @@ private fun FindReplaceBar(
                     iconTint = colorScheme.onSurfaceVariant,
                     contentDescription = strings.nextMatchDescription,
                     iconSize = 16.dp,
-                    modifier = Modifier.iconButtonSize(),
                 )
                 Box(
                     modifier = Modifier
@@ -324,7 +320,6 @@ private fun FindReplaceBar(
                     imageVector = Icons.Default.Close,
                     iconTint = colorScheme.onSurfaceVariant,
                     contentDescription = strings.closeFindBarDescription,
-                    modifier = Modifier.iconButtonSize(),
                     iconSize = 14.dp,
                 )
             }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/FindableEditorTextField.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/components/editor/FindableEditorTextField.kt
@@ -27,8 +27,6 @@ import androidx.compose.material.icons.filled.FindReplace
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -60,6 +58,7 @@ import com.apadmi.mockzilla.ui.ui.common.components.CustomTextField
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonSize
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonVariant
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomButton
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 @Composable
@@ -247,19 +246,15 @@ private fun FindReplaceBar(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
             ) {
-                IconButton(
+                CustomIconButton(
                     onClick = onToggleReplaceMode,
+                    imageVector = Icons.Default.KeyboardArrowRight,
+                    iconTint = colorScheme.onSurfaceVariant,
+                    contentDescription = if (state.isReplaceMode) strings.collapseReplaceDescription else strings.expandReplaceDescription,
                     modifier = Modifier.iconButtonSize(),
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowRight,
-                        contentDescription = if (state.isReplaceMode) strings.collapseReplaceDescription else strings.expandReplaceDescription,
-                        modifier = Modifier
-                            .size(16.dp)
-                            .rotate(chevronRotation),
-                        tint = colorScheme.onSurfaceVariant,
-                    )
-                }
+                    iconSize = 16.dp,
+                    iconDecoration = { content -> content(Modifier.rotate(chevronRotation)) }
+                )
 
                 CustomTextField(
                     value = state.searchTerm,
@@ -302,36 +297,36 @@ private fun FindReplaceBar(
                         },
                 )
 
-                IconButton(onClick = onPrev, modifier = Modifier.iconButtonSize()) {
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowUp,
-                        contentDescription = strings.previousMatchDescription,
-                        modifier = Modifier.size(16.dp),
-                        tint = colorScheme.onSurfaceVariant,
-                    )
-                }
-                IconButton(onClick = onNext, modifier = Modifier.iconButtonSize()) {
-                    Icon(
-                        imageVector = Icons.Default.KeyboardArrowDown,
-                        contentDescription = strings.nextMatchDescription,
-                        modifier = Modifier.size(16.dp),
-                        tint = colorScheme.onSurfaceVariant,
-                    )
-                }
+                CustomIconButton(
+                    onClick = onPrev,
+                    imageVector = Icons.Default.KeyboardArrowUp,
+                    iconTint = colorScheme.onSurfaceVariant,
+                    contentDescription = strings.previousMatchDescription,
+                    modifier = Modifier.iconButtonSize(),
+                    iconSize = 16.dp,
+                )
+                CustomIconButton(
+                    onClick = onNext,
+                    imageVector = Icons.Default.KeyboardArrowDown,
+                    iconTint = colorScheme.onSurfaceVariant,
+                    contentDescription = strings.nextMatchDescription,
+                    iconSize = 16.dp,
+                    modifier = Modifier.iconButtonSize(),
+                )
                 Box(
                     modifier = Modifier
                         .height(16.dp)
                         .width(1.dp)
                         .background(colorScheme.outlineVariant),
                 )
-                IconButton(onClick = onClose, modifier = Modifier.iconButtonSize()) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = strings.closeFindBarDescription,
-                        modifier = Modifier.size(14.dp),
-                        tint = colorScheme.onSurfaceVariant,
-                    )
-                }
+                CustomIconButton(
+                    onClick = onClose,
+                    imageVector = Icons.Default.Close,
+                    iconTint = colorScheme.onSurfaceVariant,
+                    contentDescription = strings.closeFindBarDescription,
+                    modifier = Modifier.iconButtonSize(),
+                    iconSize = 14.dp,
+                )
             }
 
             AnimatedVisibility(visible = state.isReplaceMode) {

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
@@ -48,7 +48,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -87,6 +86,7 @@ import com.apadmi.mockzilla.ui.ui.common.components.TogglableProgressIndicator
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonSize
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonVariant
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomButton
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.components.editor.EditorMode
 import com.apadmi.mockzilla.ui.ui.common.components.editor.FindableEditorTextField
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
@@ -146,14 +146,13 @@ private fun ColumnScope.HeadersSection(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.weight(1f),
                 )
-                IconButton(onClick = { onRemoveHeader(header) }) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(16.dp),
-                    )
-                }
+                CustomIconButton(
+                    onClick = { onRemoveHeader(header) },
+                    imageVector = Icons.Default.Close,
+                    iconTint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    contentDescription = LocalStrings.current.common.closeDescription,
+                    iconSize = 16.dp,
+                )
             }
         }
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -203,24 +202,21 @@ private fun ColumnScope.HeadersSection(
             onValueChange = { localValue = it },
         )
         val canAdd = localKey.isNotEmpty() && localValue.isNotEmpty()
-        IconButton(
+        CustomIconButton(
             onClick = {
                 onAddHeader(localKey, localValue)
                 localKey = ""
                 localValue = ""
             },
-            enabled = canAdd,
+            imageVector = Icons.Default.Add,
+            iconTint = MaterialTheme.colorScheme.onSurface,
+            contentDescription = strings.addHeaderButton,
             modifier = Modifier
                 .iconButtonSize()
                 .pointerHoverIcon(if (canAdd) PointerIcon.Hand else blockedPointerIcon),
-        ) {
-            Icon(
-                imageVector = Icons.Default.Add,
-                contentDescription = strings.addHeaderButton,
-                tint = MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.size(14.dp),
-            )
-        }
+            enabled = canAdd,
+            iconSize = 14.dp,
+        )
     }
 
     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
@@ -538,17 +534,14 @@ private fun BodySection(
             modifier = Modifier.alpha(if (isFormattable) 1f else 0f)
         )
 
-        IconButton(
+        CustomIconButton(
             onClick = onToggleExpand,
+            imageVector = if (isExpanded) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
+            iconTint = MaterialTheme.colorScheme.onSurface,
+            contentDescription = if (isExpanded) strings.collapse else strings.expand,
             modifier = Modifier.iconButtonSize(),
-        ) {
-            Icon(
-                imageVector = if (isExpanded) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
-                contentDescription = if (isExpanded) "Collapse" else "Expand",
-                modifier = Modifier.size(18.dp),
-                tint = MaterialTheme.colorScheme.onSurface,
-            )
-        }
+            iconSize = 18.dp,
+        )
     }
 
     FindableEditorTextField(

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
@@ -95,7 +95,6 @@ import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceFaint
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.createeditpreset.CreateEditPresetViewModel.*
 import com.apadmi.mockzilla.ui.utils.blockedPointerIcon
-import com.apadmi.mockzilla.ui.utils.iconButtonSize
 import com.apadmi.mockzilla.ui.utils.minimumTouchTarget
 
 import io.ktor.http.HttpStatusCode
@@ -212,7 +211,6 @@ private fun ColumnScope.HeadersSection(
             iconTint = MaterialTheme.colorScheme.onSurface,
             contentDescription = strings.addHeaderButton,
             modifier = Modifier
-                .iconButtonSize()
                 .pointerHoverIcon(if (canAdd) PointerIcon.Hand else blockedPointerIcon),
             enabled = canAdd,
             iconSize = 14.dp,
@@ -539,7 +537,6 @@ private fun BodySection(
             imageVector = if (isExpanded) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
             iconTint = MaterialTheme.colorScheme.onSurface,
             contentDescription = if (isExpanded) strings.collapse else strings.expand,
-            modifier = Modifier.iconButtonSize(),
             iconSize = 18.dp,
         )
     }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsWidget.kt
@@ -93,7 +93,6 @@ import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.details.components.Pr
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.EndpointProperties
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.RowDensity
 import com.apadmi.mockzilla.ui.utils.Platform
-import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 import org.koin.core.parameter.parametersOf
 
@@ -506,7 +505,6 @@ private fun ActivePresetBanner(
             iconTint = colorScheme.onSurfaceVariant,
             contentDescription = LocalStrings.current.common.closeDescription,
             iconSize = 16.dp,
-            modifier = Modifier.iconButtonSize(),
         )
     }
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/details/EndpointDetailsWidget.kt
@@ -33,7 +33,6 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -82,6 +81,7 @@ import com.apadmi.mockzilla.ui.ui.common.components.TogglableProgressIndicator
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonSize
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonVariant
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomButton
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.RowDensityControls
 import com.apadmi.mockzilla.ui.ui.common.components.statusColors
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalForceDarkMode
@@ -500,14 +500,14 @@ private fun ActivePresetBanner(
                 color = colorScheme.onSurfaceVariant,
             )
         }
-        IconButton(onClick = onClear, modifier = Modifier.iconButtonSize()) {
-            Icon(
-                imageVector = Icons.Default.Close,
-                contentDescription = null,
-                modifier = Modifier.size(16.dp),
-                tint = colorScheme.onSurfaceVariant
-            )
-        }
+        CustomIconButton(
+            onClick = onClear,
+            imageVector = Icons.Default.Close,
+            iconTint = colorScheme.onSurfaceVariant,
+            contentDescription = LocalStrings.current.common.closeDescription,
+            iconSize = 16.dp,
+            modifier = Modifier.iconButtonSize(),
+        )
     }
 }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsWidget.kt
@@ -22,8 +22,6 @@ import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -51,6 +49,7 @@ import com.apadmi.mockzilla.ui.ui.common.components.ResponseLatencyCard
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonSize
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.ButtonVariant
 import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomButton
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceFaint
 import com.apadmi.mockzilla.ui.ui.common.theme.warning
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.EndpointProperties
@@ -172,17 +171,14 @@ internal fun GlobalControlsWidgetIdleContent(
             )
 
             if (Platform.current == Platform.Desktop) {
-                IconButton(
+                CustomIconButton(
+                    onClick = onClose,
+                    imageVector = Icons.Default.Close,
+                    iconTint = colorScheme.onSurfaceFaint,
+                    contentDescription = strings.common.closeDescription,
                     modifier = Modifier.iconButtonSize(),
-                    onClick = onClose
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = strings.common.closeDescription,
-                        tint = colorScheme.onSurfaceFaint,
-                        modifier = Modifier.size(16.dp)
-                    )
-                }
+                    iconSize = 16.dp,
+                )
             }
         }
 

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/globalcontrols/GlobalControlsWidget.kt
@@ -56,7 +56,6 @@ import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.EndpointPro
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.endpoints.EndpointsViewModel
 import com.apadmi.mockzilla.ui.ui.common.widgets.globalcontrols.GlobalControlsViewModel.State
 import com.apadmi.mockzilla.ui.utils.Platform
-import com.apadmi.mockzilla.ui.utils.iconButtonSize
 
 import org.koin.core.parameter.parametersOf
 
@@ -176,7 +175,6 @@ internal fun GlobalControlsWidgetIdleContent(
                     imageVector = Icons.Default.Close,
                     iconTint = colorScheme.onSurfaceFaint,
                     contentDescription = strings.common.closeDescription,
-                    modifier = Modifier.iconButtonSize(),
                     iconSize = 16.dp,
                 )
             }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/monitorlogs/details/MonitorLogDetailsWidget.kt
@@ -29,7 +29,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -56,6 +55,7 @@ import com.apadmi.mockzilla.ui.ui.common.components.EmptyState
 import com.apadmi.mockzilla.ui.ui.common.components.PlatformVerticalScrollbar
 import com.apadmi.mockzilla.ui.ui.common.components.PreviewSurface
 import com.apadmi.mockzilla.ui.ui.common.components.SectionTitle
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.components.editor.EditorMode
 import com.apadmi.mockzilla.ui.ui.common.theme.LocalMonoFontFamily
 import com.apadmi.mockzilla.ui.ui.common.theme.jsonKey
@@ -272,14 +272,14 @@ private fun LogHeaderBar(
         }
     }
 
-    IconButton(onClick = onClose, Modifier.align(Alignment.TopEnd)) {
-        Icon(
-            imageVector = Icons.Default.Close,
-            contentDescription = null,
-            tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(16.dp),
-        )
-    }
+    CustomIconButton(
+        onClick = onClose,
+        imageVector = Icons.Default.Close,
+        iconTint = MaterialTheme.colorScheme.onSurfaceVariant,
+        contentDescription = LocalStrings.current.common.closeDescription,
+        iconSize = 16.dp,
+        modifier = Modifier.align(Alignment.TopEnd),
+    )
 }
 
 @Suppress("MAGIC_NUMBER")

--- a/mockzilla-management-ui/mockzilla-mobile-ui/src/commonMain/kotlin/com/apadmi/mockzilla/mobile/ui/MobileAppRoot.kt
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/src/commonMain/kotlin/com/apadmi/mockzilla/mobile/ui/MobileAppRoot.kt
@@ -72,8 +72,6 @@ import com.apadmi.mockzilla.ui.utils.minimumTouchTarget
 
 import org.koin.core.parameter.parametersOf
 
-import kotlinx.serialization.json.JsonNull.content
-
 @Suppress("MAGIC_NUMBER")
 @Composable
 internal fun MobileAppRoot(
@@ -120,8 +118,7 @@ internal fun MobileAppRoot(
                     contentDescription = LocalStrings.current.common.metaDescription,
                     modifier = Modifier
                         .clip(RoundedCornerShape(8.dp))
-                        .background(colorScheme.surface)
-                        .iconButtonSize(),
+                        .background(colorScheme.surface),
                     iconDecoration = { content ->
                         content(
                             Modifier

--- a/mockzilla-management-ui/mockzilla-mobile-ui/src/commonMain/kotlin/com/apadmi/mockzilla/mobile/ui/MobileAppRoot.kt
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/src/commonMain/kotlin/com/apadmi/mockzilla/mobile/ui/MobileAppRoot.kt
@@ -8,9 +8,7 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,8 +26,6 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Article
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -38,6 +34,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
@@ -61,6 +58,7 @@ import com.apadmi.mockzilla.ui.ui.common.DeviceRootViewModel
 import com.apadmi.mockzilla.ui.ui.common.assets.Globe
 import com.apadmi.mockzilla.ui.ui.common.assets.MockzillaLogo
 import com.apadmi.mockzilla.ui.ui.common.components.AnimatedErrorBanner
+import com.apadmi.mockzilla.ui.ui.common.components.buttons.CustomIconButton
 import com.apadmi.mockzilla.ui.ui.common.theme.AppTheme
 import com.apadmi.mockzilla.ui.ui.common.widgets.debug.DebugWidget
 import com.apadmi.mockzilla.ui.ui.common.widgets.deviceconnection.UnsupportedDeviceMockzillaVersionWidget
@@ -73,6 +71,8 @@ import com.apadmi.mockzilla.ui.utils.iconButtonSize
 import com.apadmi.mockzilla.ui.utils.minimumTouchTarget
 
 import org.koin.core.parameter.parametersOf
+
+import kotlinx.serialization.json.JsonNull.content
 
 @Suppress("MAGIC_NUMBER")
 @Composable
@@ -100,90 +100,79 @@ internal fun MobileAppRoot(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             AnimatedVisibility(showBackButton) {
-                IconButton(
+                CustomIconButton(
+                    onClick = navController::navigateUp,
+                    imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                    iconTint = colorScheme.onSurface,
+                    contentDescription = strings.common.backDescription,
                     modifier = Modifier
                         .minimumTouchTarget()
                         .clip(RoundedCornerShape(8.dp))
                         .background(colorScheme.surfaceVariant),
-                    onClick = navController::navigateUp
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                        tint = colorScheme.onSurface,
-                        contentDescription = strings.common.backDescription,
-                    )
-                }
+                )
             }
 
             AnimatedVisibility(!showBackButton) {
-                Box(
+                CustomIconButton(
+                    onClick = { navController.navigate(Destination.MetaData) },
+                    imageVector = Icons.MockzillaLogo,
+                    iconTint = Color.Unspecified,
+                    contentDescription = LocalStrings.current.common.metaDescription,
                     modifier = Modifier
                         .clip(RoundedCornerShape(8.dp))
                         .background(colorScheme.surface)
-                        .clickable {
-                            navController.navigate(Destination.MetaData)
-                        }
-                ) {
-                    Image(
-                        modifier = Modifier
-                            .iconButtonSize()
-                            .padding(vertical = 1.dp, horizontal = 4.dp),
-                        imageVector = Icons.MockzillaLogo,
-                        contentDescription = null
-                    )
-                }
+                        .iconButtonSize(),
+                    iconDecoration = { content ->
+                        content(
+                            Modifier
+                                .iconButtonSize()
+                                .padding(vertical = 1.dp, horizontal = 4.dp)
+                        )
+                    }
+                )
             }
 
             Spacer(Modifier.weight(1f))
 
             if (MockzillaBuildConfig.isDevelopmentBuild) {
-                IconButton(
+                CustomIconButton(
                     onClick = { navController.navigate(Destination.Debug) },
-                ) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.Article,
-                        tint = colorScheme.onSurfaceVariant,
-                        contentDescription = strings.common.debugDescription,
-                    )
-                }
-            }
-
-            IconButton(
-                enabled = !isOnGlobalControls,
-                onClick = {
-                    navController.navigate(Destination.GlobalControls)
-                }, modifier = Modifier
-                    .minimumTouchTarget()
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(colorScheme.surfaceVariant)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Globe,
-                    tint = colorScheme.onSurfaceVariant.copy(
-                        alpha = if (isOnGlobalControls) {
-                            0.5f
-                        } else {
-                            1f
-                        }
-                    ),
-                    contentDescription = strings.common.closeDescription,
+                    imageVector = Icons.AutoMirrored.Filled.Article,
+                    iconTint = colorScheme.onSurfaceVariant,
+                    contentDescription = strings.common.debugDescription,
                 )
             }
+
+            CustomIconButton(
+                onClick = { navController.navigate(Destination.GlobalControls) },
+                imageVector = Icons.Filled.Globe,
+                iconTint = colorScheme.onSurfaceVariant.copy(
+                    alpha = if (isOnGlobalControls) {
+                        0.5f
+                    } else {
+                        1f
+                    }
+                ),
+                contentDescription = strings.common.globalDescription,
+                modifier = Modifier
+                    .minimumTouchTarget()
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(colorScheme.surfaceVariant),
+                enabled = !isOnGlobalControls,
+            )
 
             Spacer(Modifier.width(4.dp))
 
-            IconButton(
-                onClick = onClose, modifier = Modifier
+            CustomIconButton(
+                onClick = onClose,
+                imageVector = Icons.Filled.Close,
+                iconTint = colorScheme.onSurfaceVariant,
+                contentDescription = strings.common.closeDescription,
+                modifier = Modifier
                     .minimumTouchTarget()
                     .clip(RoundedCornerShape(8.dp))
-                    .background(colorScheme.surfaceVariant)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Close,
-                    tint = colorScheme.onSurfaceVariant,
-                    contentDescription = strings.common.closeDescription,
-                )
-            }
+                    .background(colorScheme.surfaceVariant),
+            )
         }
         HorizontalDivider(
             modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
The motivation for this was adding [tooltips](https://m3.material.io/components/tooltips/overview) to all the icon buttons to improve discoverability however the Material 3 APIs are still experimental. The new component will apply tooltips to the icon buttons after reverting commit 2a8bab3b which we can do in the future once it's stabilised. While adding an icon button component I found several buttons were lacking content descriptions so have added these in which comprises the only user facing part of this PR.