### PR TITLE
fix: handle unbundled fonts

### DIFF
--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Typography.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/theme/Typography.kt
@@ -4,6 +4,8 @@ import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
@@ -12,6 +14,8 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 
 import com.apadmi.mockzilla.lib.InternalMockzillaApi
+
+import co.touchlab.kermit.Logger
 import com.apadmi.mockzilla_management_ui_common.generated.resources.Res
 import com.apadmi.mockzilla_management_ui_common.generated.resources.geist_bold
 import com.apadmi.mockzilla_management_ui_common.generated.resources.geist_medium
@@ -20,7 +24,6 @@ import com.apadmi.mockzilla_management_ui_common.generated.resources.geist_semib
 import com.apadmi.mockzilla_management_ui_common.generated.resources.jetbrainsmono_medium
 import com.apadmi.mockzilla_management_ui_common.generated.resources.jetbrainsmono_regular
 import com.apadmi.mockzilla_management_ui_common.generated.resources.jetbrainsmono_semibold
-
 import org.jetbrains.compose.resources.Font
 
 @InternalMockzillaApi
@@ -29,20 +32,28 @@ public val LocalMonoFontFamily: ProvidableCompositionLocal<FontFamily> = composi
 
 @InternalMockzillaApi
 @Composable
-public fun mockzillaFontFamily(): FontFamily = FontFamily(
-    Font(Res.font.geist_regular, weight = FontWeight.Normal),
-    Font(Res.font.geist_medium, weight = FontWeight.Medium),
-    Font(Res.font.geist_semibold, weight = FontWeight.SemiBold),
-    Font(Res.font.geist_bold, weight = FontWeight.Bold),
-)
+public fun mockzillaFontFamily(): FontFamily = if (rememberComposeFontsAvailable()) {
+    FontFamily(
+        Font(Res.font.geist_regular, weight = FontWeight.Normal),
+        Font(Res.font.geist_medium, weight = FontWeight.Medium),
+        Font(Res.font.geist_semibold, weight = FontWeight.SemiBold),
+        Font(Res.font.geist_bold, weight = FontWeight.Bold),
+    )
+} else {
+    FontFamily.Default
+}
 
 @InternalMockzillaApi
 @Composable
-public fun mockzillaMonoFontFamily(): FontFamily = FontFamily(
-    Font(Res.font.jetbrainsmono_regular, weight = FontWeight.Normal),
-    Font(Res.font.jetbrainsmono_medium, weight = FontWeight.Medium),
-    Font(Res.font.jetbrainsmono_semibold, weight = FontWeight.SemiBold),
-)
+public fun mockzillaMonoFontFamily(): FontFamily = if (rememberComposeFontsAvailable()) {
+    FontFamily(
+        Font(Res.font.jetbrainsmono_regular, weight = FontWeight.Normal),
+        Font(Res.font.jetbrainsmono_medium, weight = FontWeight.Medium),
+        Font(Res.font.jetbrainsmono_semibold, weight = FontWeight.SemiBold),
+    )
+} else {
+    FontFamily.Monospace
+}
 
 @InternalMockzillaApi
 @Suppress("MAGIC_NUMBER", "TOO_LONG_FUNCTION")
@@ -112,3 +123,37 @@ public fun mockzillaTypography(uiFont: FontFamily): Typography = Typography(
         fontWeight = FontWeight.Bold,
     ),
 )
+
+/**
+ * Probes whether the bundled Compose font resources are actually present in the app bundle.
+ *
+ * On iOS the fonts are file-based Compose resources that must be copied into the consuming app's
+ * bundle (via the `org.jetbrains.compose` Gradle plugin's resource step, CocoaPods `spec.resources`,
+ * etc). If a consumer doesn't bundle them, the lazy [Font] loaders would otherwise throw
+ * `MissingResourceException` during text layout and hard-crash the app. Reading the bytes up front
+ * hits the same resource reader but is catchable, letting us fall back to system fonts instead.
+ *
+ * This only seems to apps that use KMP but not CMP
+ *
+ * See https://youtrack.jetbrains.com/issue/KT-66790.
+ */
+@Suppress("FUNCTION_BOOLEAN_PREFIX")
+@Composable
+private fun rememberComposeFontsAvailable(): Boolean {
+    val available by produceState(initialValue = false) {
+        value = runCatching { Res.readBytes("font/geist_regular.ttf") }.isSuccess
+        if (value) {
+            Logger.d(tag = "MockzillaFonts") {
+                "Mockzilla compose font resources loaded; using bundled Geist/JetBrains Mono fonts."
+            }
+        } else {
+            Logger.w(tag = "MockzillaFonts") {
+                "Mockzilla compose font resources were not found in the app bundle - falling back to " +
+                        "system fonts. This usually means the consuming iOS/KMP module isn't bundling " +
+                        "compose-resources: apply the 'org.jetbrains.compose' Gradle plugin and embed the " +
+                        "framework via embedAndSignAppleFrameworkForXcode / syncFramework. See KT-66790."
+            }
+        }
+    }
+    return available
+}


### PR DESCRIPTION
Apps that consume the mobile UI via gradle but don't actually apply the compose plugin don't execute the task that copies over the font resources causing a crash

e.g iOS KMP app (but not CMP).

We could inline the fonts or provide instructions to applying the compose plugin but both feel heavy handed. The font makes a big difference in the desktop app but for embedded UI it's not as important so we suppress it
