### PR TITLE
feat: add ability to save presets without closing the window

### DIFF
--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/En.kt
@@ -285,7 +285,7 @@ public val EnStrings: Strings = Strings(
             headersTitle = "Headers",
             addHeaderTitle = "Add New Header",
             addHeaderButton = "Add Header",
-            save = "Save",
+            save = "Save & Close",
             addHeaderKeyPlaceholder = "Header name",
             addHeaderValuePlaceholder = "Value",
             unset = "Unset",
@@ -298,6 +298,7 @@ public val EnStrings: Strings = Strings(
             jsonErrorTitle = "Invalid JSON:",
             collapse = "Collapse",
             expand = "Expand",
+            apply = "Apply"
         ),
         openSourceLicenses = Strings.Widgets.OpenSourceLicenses(
             error = "Failed to load licences",

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/i18n/Strings.kt
@@ -365,6 +365,7 @@ public data class Strings(
             val unset: String,
             val save: String,
             val cancel: String,
+            val apply: String,
             val endpointSubtitle: (endpointName: String) -> String,
             val statusCodeRowLabel: String,
             val bodyTypeLabel: String,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetViewModel.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetViewModel.kt
@@ -117,7 +117,7 @@ internal class CreateEditPresetViewModel(
         }
     }
 
-    fun save() = viewModelScope.launch {
+    fun save(shouldNavigateOnCompletion: Boolean) = viewModelScope.launch {
         val currentState = state.value as? State.Editing ?: return@launch
         val appName = when (Platform.current) {
             Platform.Desktop -> "Mockzilla Desktop"
@@ -148,7 +148,7 @@ internal class CreateEditPresetViewModel(
                 committedBody = currentState.body,
                 committedStatusCode = currentState.statusCode,
                 committedHeaders = currentState.headers,
-                navigateUp = true
+                navigateUp = shouldNavigateOnCompletion
             )
         }.onFailure {
             eventBus.send(Event.GenericError(GenericErrorableOperation.ApplyPreset, it))

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
@@ -94,6 +94,7 @@ import com.apadmi.mockzilla.ui.ui.common.theme.jsonKey
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceFaint
 import com.apadmi.mockzilla.ui.ui.common.theme.onSurfaceMuted
 import com.apadmi.mockzilla.ui.ui.common.widgets.endpoints.createeditpreset.CreateEditPresetViewModel.*
+import com.apadmi.mockzilla.ui.utils.Platform
 import com.apadmi.mockzilla.ui.utils.blockedPointerIcon
 import com.apadmi.mockzilla.ui.utils.minimumTouchTarget
 
@@ -612,16 +613,19 @@ private fun PanelHeader(
                 color = MaterialTheme.colorScheme.onSurfaceMuted,
             )
         }
-        CustomButton(
-            label = strings.widgets.createEditPreset.cancel,
-            variant = ButtonVariant.Outline,
-            onClick = onCancel,
-        )
-        CustomButton(
-            label = strings.widgets.createEditPreset.apply,
-            variant = ButtonVariant.Soft,
-            onClick = onApply,
-        )
+
+        if (Platform.current == Platform.Desktop) {
+            CustomButton(
+                label = strings.widgets.createEditPreset.cancel,
+                variant = ButtonVariant.Outline,
+                onClick = onCancel,
+            )
+            CustomButton(
+                label = strings.widgets.createEditPreset.apply,
+                variant = ButtonVariant.Soft,
+                onClick = onApply,
+            )
+        }
         CustomButton(
             label = strings.widgets.createEditPreset.save,
             variant = ButtonVariant.Solid,

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/commonMain/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetWidget.kt
@@ -225,6 +225,7 @@ private fun ColumnScope.PopulatedState(
     state: State.Editing,
     endpointName: String?,
     onCancel: () -> Unit,
+    onApply: () -> Unit,
     onSave: () -> Unit,
     onStatusCodeSelected: (HttpStatusCode) -> Unit,
     onNewResponseType: (State.Editing.ResponseType) -> Unit,
@@ -241,7 +242,7 @@ private fun ColumnScope.PopulatedState(
         enter = fadeIn() + expandVertically(expandFrom = Alignment.Top),
         exit = fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top),
     ) {
-        PanelHeader(state, onCancel, onSave)
+        PanelHeader(state = state, onCancel = onCancel, onApply = onApply, onSave = onSave)
     }
 
     AnimatedVisibility(
@@ -389,7 +390,8 @@ public fun CreateEditPresetWidget(
             cleanupVm()
             onCancel()
         },
-        onSave = viewModel::save,
+        onSave = { viewModel.save(shouldNavigateOnCompletion = true) },
+        onApply = { viewModel.save(shouldNavigateOnCompletion = false) },
         onStatusCodeSelected = viewModel::onNewStatusCode,
         onNewResponseType = viewModel::onNewResponseType,
         onNewResponseBody = viewModel::onNewResponseBody,
@@ -406,6 +408,7 @@ internal fun CreateEditPresetWidgetContent(
     endpointName: String? = null,
     onCancel: () -> Unit = {},
     onSave: () -> Unit,
+    onApply: () -> Unit,
     onStatusCodeSelected: (HttpStatusCode) -> Unit,
     onNewResponseType: (State.Editing.ResponseType) -> Unit,
     onNewResponseBody: (String) -> Unit,
@@ -451,6 +454,7 @@ internal fun CreateEditPresetWidgetContent(
                 endpointName = endpointName,
                 onCancel = onCancel,
                 onSave = onSave,
+                onApply = onApply,
                 onStatusCodeSelected = onStatusCodeSelected,
                 onNewResponseType = onNewResponseType,
                 onNewResponseBody = onNewResponseBody,
@@ -570,6 +574,7 @@ private fun BodySection(
 private fun PanelHeader(
     state: State.Editing,
     onCancel: () -> Unit,
+    onApply: () -> Unit,
     onSave: () -> Unit,
     strings: Strings = LocalStrings.current,
 ) = Column(
@@ -611,6 +616,11 @@ private fun PanelHeader(
             label = strings.widgets.createEditPreset.cancel,
             variant = ButtonVariant.Outline,
             onClick = onCancel,
+        )
+        CustomButton(
+            label = strings.widgets.createEditPreset.apply,
+            variant = ButtonVariant.Soft,
+            onClick = onApply,
         )
         CustomButton(
             label = strings.widgets.createEditPreset.save,
@@ -816,6 +826,7 @@ private fun CreateEditPresetWidgetPreview() = PreviewSurface {
         onNewResponseBody = {},
         onAddHeader = { _, _ -> },
         onRemoveHeader = {},
+        onApply = {},
         onRetry = {}
     )
 }

--- a/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetViewModelTests.kt
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/src/desktopTest/kotlin/com/apadmi/mockzilla/ui/ui/common/widgets/endpoints/createeditpreset/CreateEditPresetViewModelTests.kt
@@ -283,7 +283,7 @@ class CreateEditPresetViewModelTests : CoroutineTest() {
         assertTrue((sut.state.value as State.Editing).isDirty)
 
         /* Run Test */
-        sut.save()
+        sut.save(shouldNavigateOnCompletion = true)
         yield()
 
         /* Verify */
@@ -308,7 +308,7 @@ class CreateEditPresetViewModelTests : CoroutineTest() {
         val tokenBefore = (sut.state.value as State.Editing).syncToken
 
         /* Run Test */
-        sut.save()
+        sut.save(shouldNavigateOnCompletion = true)
         yield()
 
         /* Verify */
@@ -328,7 +328,7 @@ class CreateEditPresetViewModelTests : CoroutineTest() {
         yield()
 
         /* Run Test */
-        sut.save()
+        sut.save(shouldNavigateOnCompletion = true)
         yield()
 
         /* Verify */
@@ -354,7 +354,7 @@ class CreateEditPresetViewModelTests : CoroutineTest() {
         val sut = createSut()
         yield()
 
-        sut.save()
+        sut.save(shouldNavigateOnCompletion = true)
         yield()
 
         assertTrue((sut.state.value as State.Editing).navigateUp)


### PR DESCRIPTION
## Description

Adds an "Apply" button on desktop (requested by Zsolt). 

Hidden this (and the cancel button) on mobile since neither are actually useful there.

<img width="511" height="579" alt="Screenshot 2026-07-16 at 08 13 01" src="https://github.com/user-attachments/assets/cbe56e12-3bad-4ed5-9099-ed656e54ec3d" />
<img width="391" height="698" alt="Screenshot 2026-07-16 at 08 12 18" src="https://github.com/user-attachments/assets/84952727-623c-4ecd-8674-3122aedb7784" />

## Checklist

- [x] Tests added/updated for the change
- [x] `./gradlew spotlessApply` run (for Kotlin changes) / formatting run (for Dart/Swift changes)
