### PR TITLE
feat: add the ability to the api to update the preset by name

### DIFF
--- a/mockzilla-common/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/models/ApplyPresetRequestDto.kt
+++ b/mockzilla-common/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/models/ApplyPresetRequestDto.kt
@@ -1,0 +1,15 @@
+package com.apadmi.mockzilla.lib.internal.models
+
+import com.apadmi.mockzilla.lib.InternalMockzillaApi
+import kotlinx.serialization.Serializable
+
+/**
+ * Payload for applying a preset by name rather than supplying individual properties
+ *
+ * @property presetName
+ */
+@InternalMockzillaApi
+@Serializable
+public data class ApplyPresetRequestDto(
+    val presetName: String
+)

--- a/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/MockzillaManagement.kt
+++ b/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/MockzillaManagement.kt
@@ -160,6 +160,24 @@ public interface MockzillaManagement {
             key: EndpointConfiguration.Key,
             dashboardOverridePreset: DashboardOverridePreset
         ): Result<Unit>
+
+        /**
+         * Applies a code-defined dashboard preset to the endpoint identified by [key] on the
+         * device at [connection] by looking it up by [presetName], overriding the endpoint's
+         * response until the override is cleared.
+         *
+         * @param connection The device to target.
+         * @param key The key of the endpoint to update.
+         * @param presetName The name of the preset to apply, as configured via
+         * [EndpointConfiguration.Builder.configureDashboardOverrides].
+         * @return [Result.success] on success, [Result.failure] if the request could not be
+         * completed or no endpoint/preset matches [key]/[presetName].
+         */
+        public suspend fun applyPresetByName(
+            connection: MockzillaConnectionConfig,
+            key: EndpointConfiguration.Key,
+            presetName: String
+        ): Result<Unit>
     }
 
     /**

--- a/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/MockzillaManagementRepositoryImpl.kt
+++ b/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/MockzillaManagementRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.apadmi.mockzilla.management.internal
 
 import com.apadmi.mockzilla.lib.InternalMockzillaApi
+import com.apadmi.mockzilla.lib.internal.models.ApplyPresetRequestDto
 import com.apadmi.mockzilla.lib.internal.models.ClearCachesRequestDto
 import com.apadmi.mockzilla.lib.internal.models.LogEvent
 import com.apadmi.mockzilla.lib.internal.models.MockDataResponseDto
@@ -20,6 +21,7 @@ import com.apadmi.mockzilla.management.internal.ktor.KtorRequestRunner
 import com.apadmi.mockzilla.management.internal.ktor.delete
 import com.apadmi.mockzilla.management.internal.ktor.get
 import com.apadmi.mockzilla.management.internal.ktor.patch
+import com.apadmi.mockzilla.management.internal.ktor.put
 
 import co.touchlab.kermit.Logger
 import io.ktor.client.call.body
@@ -51,6 +53,12 @@ public interface MockzillaManagementRepository {
         entries: List<SerializableEndpointPatchItemDto>,
         connection: MockzillaConnectionConfig
     ): Result<Unit>
+
+    public suspend fun applyPresetByName(
+        connection: MockzillaConnectionConfig,
+        key: EndpointConfiguration.Key,
+        presetName: String
+    ): Result<SerializableEndpointConfig>
 
     public suspend fun fetchMonitorLogsAndClearBuffer(connection: MockzillaConnectionConfig, hideFromLogs: Boolean): Result<MonitorLogsResponse>
     public suspend fun fetchMonitorLogsSince(
@@ -109,6 +117,20 @@ MockzillaManagement.AppIconService {
         entry: SerializableEndpointPatchItemDto,
         connection: MockzillaConnectionConfig,
     ) = updateMockDataEntries(listOf(entry), connection)
+
+    override suspend fun applyPresetByName(
+        connection: MockzillaConnectionConfig,
+        key: EndpointConfiguration.Key,
+        presetName: String
+    ) = runner<SerializableEndpointConfig> {
+        put(connection, "/api/mock-data") {
+            url {
+                appendPathSegments(key.raw)
+            }
+            contentType(ContentType.Application.Json)
+            setBody(ApplyPresetRequestDto(presetName))
+        }
+    }.alsoLogFailure("/api/mock-data/{key}")
 
     override suspend fun updateMockDataEntries(
         entries: List<SerializableEndpointPatchItemDto>,

--- a/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorRequestRunner.kt
+++ b/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/ktor/KtorRequestRunner.kt
@@ -10,6 +10,7 @@ import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.patch
+import io.ktor.client.request.put
 import io.ktor.client.request.url
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
@@ -76,6 +77,15 @@ internal suspend inline fun HttpClient.patch(
     path: String,
     block: HttpRequestBuilder.() -> Unit = {}
 ): HttpResponse = patch {
+    url(connection.url(path))
+    block()
+}
+
+internal suspend inline fun HttpClient.put(
+    connection: MockzillaConnectionConfig,
+    path: String,
+    block: HttpRequestBuilder.() -> Unit = {}
+): HttpResponse = put {
     url(connection.url(path))
     block()
 }

--- a/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/service/UpdateServiceImpl.kt
+++ b/mockzilla-management/src/commonMain/kotlin/com/apadmi/mockzilla/management/internal/service/UpdateServiceImpl.kt
@@ -50,4 +50,10 @@ internal class UpdateServiceImpl(
             appliedPresetOverride = SetOrDont.Set(dashboardOverridePreset),
         ), connection
     )
+
+    override suspend fun applyPresetByName(
+        connection: MockzillaConnectionConfig,
+        key: EndpointConfiguration.Key,
+        presetName: String
+    ) = repo.applyPresetByName(connection, key, presetName).map { Unit }
 }

--- a/mockzilla-management/src/commonTest/kotlin/com/apadmi/mockzilla/management/internal/MockzillaManagementRepositoryIntegrationTests.kt
+++ b/mockzilla-management/src/commonTest/kotlin/com/apadmi/mockzilla/management/internal/MockzillaManagementRepositoryIntegrationTests.kt
@@ -224,6 +224,63 @@ class MockzillaManagementRepositoryIntegrationTests {
         }
 
     @Test
+    fun `applyPresetByName - matching preset - returns updated config`() =
+        runIntegrationTest(
+            dummyAppName,
+            dummyAppVersion,
+            createSut = { it },
+            config = MockzillaConfig.Builder()
+                .setPort(0)  // Port determined at runtime
+                .addEndpoint(
+                    EndpointConfiguration.Builder("my key")
+                        .configureDashboardOverrides {
+                            addPreset(PartialMockzillaHttpResponse(body = "preset"), "name", "desc")
+                        }.build()
+                )
+                .build()
+        ) { sut, connection, _ ->
+            /* Run Test */
+            val result = sut.applyPresetByName(connection, EndpointConfiguration.Key("my key"), "name")
+
+            /* Verify */
+            assertEquals(
+                SerializableEndpointConfig.allNulls("my key", "my key", Int.MIN_VALUE).copy(
+                    appliedPresetOverride = DashboardOverridePreset(
+                        "name",
+                        "desc",
+                        response = PartialMockzillaHttpResponse(body = "preset"),
+                        type = null
+                    )
+                ),
+                result.getOrThrow()
+            )
+        }
+
+    @Test
+    fun `applyPresetByName - unknown preset name - returns failure`() =
+        runIntegrationTest(
+            dummyAppName,
+            dummyAppVersion,
+            createSut = { it },
+            config = MockzillaConfig.Builder()
+                .setPort(0)  // Port determined at runtime
+                .addEndpoint(
+                    EndpointConfiguration.Builder("my key")
+                        .configureDashboardOverrides {
+                            addPreset(PartialMockzillaHttpResponse(body = "preset"), "name", "desc")
+                        }.build()
+                )
+                .build()
+        ) { sut, connection, _ ->
+            /* Run Test */
+            val result =
+                sut.applyPresetByName(connection, EndpointConfiguration.Key("my key"), "no such preset")
+
+            /* Verify */
+            assertTrue(result.isFailure)
+        }
+
+    @Test
     fun `clearCaches and clearAllCaches - behave correctly`() =
         runIntegrationTest(
             dummyAppName,

--- a/mockzilla/src/allButWebMain/kotlin/com/apadmi/mockzilla/lib/internal/ServerModuleConfig.kt
+++ b/mockzilla/src/allButWebMain/kotlin/com/apadmi/mockzilla/lib/internal/ServerModuleConfig.kt
@@ -1,6 +1,7 @@
 package com.apadmi.mockzilla.lib.internal
 
 import com.apadmi.mockzilla.lib.internal.di.DependencyInjector
+import com.apadmi.mockzilla.lib.internal.models.ApplyPresetRequestDto
 import com.apadmi.mockzilla.lib.internal.models.ClearCachesRequestDto
 import com.apadmi.mockzilla.lib.internal.models.MockDataResponseDto
 import com.apadmi.mockzilla.lib.internal.models.MonitorLogsResponse
@@ -69,12 +70,21 @@ internal fun Application.configureEndpoints(
             }
         }
         patch("/api/mock-data") {
-            di.logger.v { "Handling POST mock-data: ${call.request.uri}" }
+            di.logger.v { "Handling PATCH mock-data: ${call.request.uri}" }
             safeResponse(di.logger) { call ->
                 call.allowCors()
                 val patches = call.receive<SerializableEndpointConfigPatchRequestDto>().entries
                 di.managementApiController.patchEntries(patches)
                 call.respond(HttpStatusCode.Created)
+            }
+        }
+        put("/api/mock-data/{key}") {
+            di.logger.v { "Handling PUT mock-data: ${call.request.uri}" }
+            safeResponse(di.logger) { call ->
+                call.allowCors()
+                val presetName = call.receive<ApplyPresetRequestDto>().presetName
+                val result = di.managementApiController.applyPresetByName(call.extractKey(), presetName)
+                result?.let { call.respond(it) } ?: call.respond(HttpStatusCode.NotFound)
             }
         }
         delete("/api/mock-data/all") {

--- a/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/controller/ManagementApiController.kt
+++ b/mockzilla/src/commonMain/kotlin/com/apadmi/mockzilla/lib/internal/controller/ManagementApiController.kt
@@ -2,6 +2,7 @@ package com.apadmi.mockzilla.lib.internal.controller
 
 import com.apadmi.mockzilla.lib.internal.models.SerializableEndpointConfig
 import com.apadmi.mockzilla.lib.internal.models.SerializableEndpointPatchItemDto
+import com.apadmi.mockzilla.lib.internal.models.SetOrDont
 import com.apadmi.mockzilla.lib.internal.service.LocalCacheService
 import com.apadmi.mockzilla.lib.internal.service.MockServerMonitor
 import com.apadmi.mockzilla.lib.models.DashboardOptionsConfig
@@ -28,6 +29,30 @@ internal class ManagementApiController(
     suspend fun getAllMockDataEntries() = endpoints.map { config ->
         localCacheService.getLocalCache(config.key)?.copy(name = config.name)
             ?: SerializableEndpointConfig.allNulls(config.key, config.name, config.versionCode)
+    }
+
+    /**
+     * Applies a code-defined dashboard preset to an endpoint by looking it up by name.
+     *
+     * @param key The key of the endpoint to update.
+     * @param presetName The name of the preset to apply.
+     * @return The updated [SerializableEndpointConfig], or `null` if no endpoint exists for [key]
+     * or no preset with that name is configured for that endpoint.
+     */
+    suspend fun applyPresetByName(key: EndpointConfiguration.Key, presetName: String): SerializableEndpointConfig? {
+        val endpoint = endpoints.firstOrNull { it.key == key } ?: return null
+        val preset = endpoint.dashboardOptionsConfig.presets.firstOrNull { it.name == presetName } ?: return null
+
+        patchEntries(
+            listOf(
+                SerializableEndpointPatchItemDto.allUnset(key).copy(
+                    appliedPresetOverride = SetOrDont.Set(preset)
+                )
+            )
+        )
+
+        return localCacheService.getLocalCache(key)?.copy(name = endpoint.name)
+            ?: SerializableEndpointConfig.allNulls(key, endpoint.name, endpoint.versionCode)
     }
 
     fun getDashboardConfig(key: EndpointConfiguration.Key): DashboardOptionsConfig {

--- a/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/integration/ApiIntegrationTests.kt
+++ b/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/integration/ApiIntegrationTests.kt
@@ -243,6 +243,106 @@ class ApiIntegrationTests {
         }
 
     @Test
+    fun `PUT mock-data by key - applies preset by name - updates cache as expected`() =
+        runIntegrationTest(
+            MockzillaConfig.Builder()
+                .setPort(0)  // Port determined at runtime
+                .addEndpoint(EndpointConfiguration.Builder("id")
+                    .configureDashboardOverrides {
+                        addPreset(
+                            MockzillaHttpResponse(
+                                HttpStatusCode.Created,
+                                emptyMap(),
+                                "preset body"
+                            ),
+                            name = "Preset name",
+                            description = "Preset description",
+                            type = DashboardOverridePreset.Type.Informational
+                        )
+                    }
+                    .build())
+                .build()
+        ) { params, cacheService ->
+            /* Run Test */
+            val response = HttpClient().put(
+                "${params.apiBaseUrl}/mock-data/id"
+            ) {
+                contentType(ContentType.Application.Json)
+                setBody(Json.encodeToString(ApplyPresetRequestDto("Preset name")))
+            }
+
+            /* Verify */
+            val expectedPreset = DashboardOverridePreset(
+                name = "Preset name",
+                description = "Preset description",
+                type = DashboardOverridePreset.Type.Informational,
+                response = PartialMockzillaHttpResponse(
+                    HttpStatusCode.Created,
+                    emptyMap(),
+                    "preset body"
+                )
+            )
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals(
+                SerializableEndpointConfig.allNulls("id", "id", Int.MIN_VALUE).copy(
+                    appliedPresetOverride = expectedPreset
+                ),
+                JsonProvider.json.decodeFromString<SerializableEndpointConfig>(response.bodyAsText())
+            )
+            assertEquals(
+                SerializableEndpointConfig.allNulls("id", "id", Int.MIN_VALUE).copy(
+                    appliedPresetOverride = expectedPreset
+                ),
+                cacheService.getLocalCache(EndpointConfiguration.Key("id"))
+            )
+        }
+
+    @Test
+    fun `PUT mock-data by key - unknown preset name - returns 404`() =
+        runIntegrationTest(
+            MockzillaConfig.Builder()
+                .setPort(0)  // Port determined at runtime
+                .addEndpoint(EndpointConfiguration.Builder("id")
+                    .configureDashboardOverrides {
+                        addPreset(MockzillaHttpResponse(HttpStatusCode.Created, emptyMap(), "preset body"))
+                    }
+                    .build())
+                .build()
+        ) { params, cacheService ->
+            /* Run Test */
+            val response = HttpClient().put(
+                "${params.apiBaseUrl}/mock-data/id"
+            ) {
+                contentType(ContentType.Application.Json)
+                setBody(Json.encodeToString(ApplyPresetRequestDto("no such preset")))
+            }
+
+            /* Verify */
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertNull(cacheService.getLocalCache(EndpointConfiguration.Key("id")))
+        }
+
+    @Test
+    fun `PUT mock-data by key - unknown endpoint key - returns 404`() =
+        runIntegrationTest(
+            MockzillaConfig.Builder()
+                .setPort(0)  // Port determined at runtime
+                .addEndpoint(EndpointConfiguration.Builder("id"))
+                .build()
+        ) { params, _ ->
+            /* Run Test */
+            val response = HttpClient().put(
+                "${params.apiBaseUrl}/mock-data/does-not-exist"
+            ) {
+                contentType(ContentType.Application.Json)
+                setBody(Json.encodeToString(ApplyPresetRequestDto("whatever")))
+            }
+
+            /* Verify */
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+    @Test
     fun `GET monitor-logs - returns as expected`() = runIntegrationTest(
         MockzillaConfig.Builder()
             .setPort(0)  // Port determined at runtime

--- a/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/internal/controller/ManagementApiControllerTests.kt
+++ b/mockzilla/src/commonTest/kotlin/com/apadmi/mockzilla/lib/internal/controller/ManagementApiControllerTests.kt
@@ -3,6 +3,7 @@ package com.apadmi.mockzilla.lib.internal.controller
 import com.apadmi.mockzilla.lib.internal.models.LogEvent
 import com.apadmi.mockzilla.lib.internal.models.SerializableEndpointConfig
 import com.apadmi.mockzilla.lib.internal.models.SerializableEndpointPatchItemDto
+import com.apadmi.mockzilla.lib.internal.models.SetOrDont
 import com.apadmi.mockzilla.lib.models.DashboardOptionsConfig
 import com.apadmi.mockzilla.lib.models.DashboardOverridePreset
 import com.apadmi.mockzilla.lib.models.EndpointConfiguration
@@ -233,6 +234,70 @@ class ManagementApiControllerTests {
                     )
                 )
             ),
+            result
+        )
+    }
+
+    @Test
+    fun `applyPresetByName - unknown endpoint key - returns null`() = runTest {
+        /* Setup */
+        val sut = ManagementApiController(
+            dummyEndpoints,
+            FakeLocalCacheService(),
+            FakeMockServerMonitor()
+        )
+
+        /* Run Test */
+        val result = sut.applyPresetByName(EndpointConfiguration.Key("random key"), "p1")
+
+        /* Verify */
+        assertNull(result)
+    }
+
+    @Test
+    fun `applyPresetByName - unknown preset name - returns null`() = runTest {
+        /* Setup */
+        val fakeLocalCacheService = FakeLocalCacheService()
+        val sut = ManagementApiController(dummyEndpoints, fakeLocalCacheService, FakeMockServerMonitor())
+
+        /* Run Test */
+        val result = sut.applyPresetByName(EndpointConfiguration.Key("my-second-id"), "no such preset")
+
+        /* Verify */
+        assertNull(result)
+        assertNull(fakeLocalCacheService.patchLocalCachesArgument)
+    }
+
+    @Test
+    fun `applyPresetByName - calls through - patches cache with matched preset and returns updated entry`() = runTest {
+        /* Setup */
+        val expectedPreset = DashboardOverridePreset(
+            response = PartialMockzillaHttpResponse(
+                statusCode = HttpStatusCode.Created,
+                headers = mapOf("test-header" to "test-value"),
+                body = "my response body"
+            ), name = "p1",
+            description = "p2",
+            type = DashboardOverridePreset.Type.Informational
+        )
+        val endpoint = dummyEndpoints.first { it.key == EndpointConfiguration.Key("my-second-id") }
+        val fakeLocalCacheService = FakeLocalCacheService()
+        val sut = ManagementApiController(dummyEndpoints, fakeLocalCacheService, FakeMockServerMonitor())
+
+        /* Run Test */
+        val result = sut.applyPresetByName(endpoint.key, "p1")
+
+        /* Verify */
+        assertEquals(
+            mapOf(
+                endpoint to SerializableEndpointPatchItemDto.allUnset(endpoint.key).copy(
+                    appliedPresetOverride = SetOrDont.Set(expectedPreset)
+                )
+            ),
+            fakeLocalCacheService.patchLocalCachesArgument
+        )
+        assertEquals(
+            SerializableEndpointConfig.allNulls(endpoint.key, endpoint.name, endpoint.versionCode),
             result
         )
     }

--- a/mockzilla/src/jsMain/kotlin/com/apadmi/mockzilla/lib/internal/ServerModuleConfig.kt
+++ b/mockzilla/src/jsMain/kotlin/com/apadmi/mockzilla/lib/internal/ServerModuleConfig.kt
@@ -1,6 +1,7 @@
 package com.apadmi.mockzilla.lib.internal
 
 import com.apadmi.mockzilla.lib.internal.di.DependencyInjector
+import com.apadmi.mockzilla.lib.internal.models.ApplyPresetRequestDto
 import com.apadmi.mockzilla.lib.internal.models.ClearCachesRequestDto
 import com.apadmi.mockzilla.lib.internal.models.MockDataResponseDto
 import com.apadmi.mockzilla.lib.internal.models.MonitorLogsResponse
@@ -144,6 +145,29 @@ internal fun configureEndpoints(
             MockzillaHttpResponse(
                 statusCode = HttpStatusCode.Created,
                 headers = CorsUtils.allowAllHeaders + jsonHeader
+            )
+        }
+    },
+    Msw.http.put("$baseUrl/api/mock-data/*") { info ->
+        di.logger.v { "Handling PUT mock-data: ${info.request.url}" }
+        info.request.safeResponse(di.logger, scope) { request ->
+            val keyRegex = ".*/mock-data/(.*)".toRegex()
+            val key = keyRegex.matchEntire(info.request.url)?.groupValues?.last()
+                ?.decodeURLPart()
+                ?: throw IllegalStateException("Missing key in url ${info.request.url}")
+            val presetName = JsonProvider.json.decodeFromString<ApplyPresetRequestDto>(
+                request.text().await()
+            ).presetName
+
+            val result = di.managementApiController.applyPresetByName(EndpointConfiguration.Key(key), presetName)
+            result?.let {
+                MockzillaHttpResponse(
+                    body = JsonProvider.json.encodeToString(it),
+                    headers = CorsUtils.allowAllHeaders + jsonHeader
+                )
+            } ?: MockzillaHttpResponse(
+                statusCode = HttpStatusCode.NotFound,
+                headers = CorsUtils.allowAllHeaders
             )
         }
     },


### PR DESCRIPTION
## Description

Adds the ability to update presets by name with a simple API call. Designed to make it easier to use in cases like UI automation testing
