### PR TITLE
fix: fix add device button alignment

### DIFF
--- a/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/devicetabs/DeviceTabsWidget.kt
+++ b/mockzilla-management-ui/mockzilla-desktop/src/commonMain/kotlin/com/apadmi/mockzilla/desktop/ui/devicetabs/DeviceTabsWidget.kt
@@ -205,6 +205,9 @@ internal fun DeviceTabsWidgetContent(
                     }
                     if (state.devices.isNotEmpty()) {
                         CustomIconButton(
+                            modifier = Modifier
+                                .align(Alignment.CenterVertically)
+                                .padding(start = 8.dp),
                             onClick = onAddNewDevice,
                             imageVector = Icons.Filled.Add,
                             iconTint = colorScheme.onSurfaceVariant,


### PR DESCRIPTION
## Description

Fixes alignment of add device button

Before:
<img width="224" height="68" alt="Screenshot 2026-07-16 at 08 42 37" src="https://github.com/user-attachments/assets/9dfee76d-1081-4faa-86c3-698343b54e1a" />

After:
<img width="254" height="64" alt="Screenshot 2026-07-16 at 08 41 06" src="https://github.com/user-attachments/assets/b27db672-1b8a-4f85-bcec-bbf9d13b2b23" />

## Checklist

- [x] Tests added/updated for the change
- [x] `./gradlew spotlessApply` run (for Kotlin changes) / formatting run (for Dart/Swift changes)

