### PR TITLE
fix: fix iOS scrolling

### DIFF
--- a/fastlane/fastfiles/demo_kmm.rb
+++ b/fastlane/fastfiles/demo_kmm.rb
@@ -6,7 +6,7 @@ platform :ios do
             project: "./samples/demo-kmm/iosApp/iosApp.xcodeproj",
             skip_package_ipa: true,
             skip_archive: true,
-            destination: "generic/platform=iOS Simulator"
+            skip_codesigning: true
         )
     end
 end

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ lyricist = "1.7.0" # https://github.com/adrielcafe/lyricist
 ktor = "3.4.3" # https://github.com/ktorio/ktor
 
 # Compose
-compose = "1.10.3" # https://github.com/JetBrains/compose-multiplatform
+compose = "1.11.1" # https://github.com/JetBrains/compose-multiplatform
 
 # DI
 koin = "4.2.1" # https://github.com/InsertKoinIO/koin

--- a/mockzilla-management-ui/mockzilla-management-ui-common/build.gradle.kts
+++ b/mockzilla-management-ui/mockzilla-management-ui-common/build.gradle.kts
@@ -33,7 +33,6 @@ kotlin {
 
     val xcf = XCFramework()
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {

--- a/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
+++ b/mockzilla-management-ui/mockzilla-mobile-ui/build.gradle.kts
@@ -58,7 +58,6 @@ kotlin {
 
     val xcf = XCFramework()
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {

--- a/samples/demo-kmm/shared/build.gradle.kts
+++ b/samples/demo-kmm/shared/build.gradle.kts
@@ -13,7 +13,6 @@ kotlin {
     androidTarget()
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64()
     ).forEach {


### PR DESCRIPTION
Scrolling was broken on the previous compose versions, fixed here: https://github.com/JetBrains/compose-multiplatform-core/pull/2883/changes

Does mean dropping simulator support for the mobile ui but given this is all still alpha this isn't a big deal
